### PR TITLE
Polyfill for removed Lua functions

### DIFF
--- a/wikitextprocessor/core.py
+++ b/wikitextprocessor/core.py
@@ -63,15 +63,16 @@ def phase2_page_handler(dt):
             assert isinstance(data, str)
         else:
             data = None
-        try:
-            ret = _global_page_handler(model, title, data)
-            return True, title, start_t, ret
-        except Exception as e:
-            lst = traceback.format_exception(type(e), value=e,
-                                             tb=e.__traceback__)
-            msg = ("=== EXCEPTION while parsing page \"{}\":\n".format(title) +
-                   "".join(lst))
-            return False, title, start_t, msg
+        # TODO: traceback.format_exception doesn't give full backtrace
+        # try:
+        ret = _global_page_handler(model, title, data)
+        return True, title, start_t, ret
+        # except Exception as e:
+        #     lst = traceback.format_exception(type(e), value=e,
+        #                                      tb=e.__traceback__)
+        #     msg = ("=== EXCEPTION while parsing page \"{}\":\n".format(title) +
+        #            "".join(lst))
+        #     return False, title, start_t, msg
 
     finally:
         if debug_hangs:

--- a/wikitextprocessor/luaexec.py
+++ b/wikitextprocessor/luaexec.py
@@ -377,6 +377,24 @@ def call_lua_sandbox(ctx, invoke_args, expander, parent, timeout):
     ctx.lua_depth += 1
     lua = ctx.lua
 
+    # Wikipedia uses Lua 5.1, and lupa uses 5.4. Some methods
+    # were removed between now and then, so we need this polyfill:
+    lua.execute(
+"""
+table.maxn = function(tab)
+if type(tab) ~= 'table' then
+    error('table.maxn param #1 tab expect "table", got "' .. type(tab) .. '"', 2)
+end
+local length = 0
+for k in pairs(tab) do
+    if type(k) == 'number' and length < k and math.floor(k) == k then
+    length = k
+    end
+end
+return length
+end
+""")
+
     # Get module and function name
     modname = expander(invoke_args[0]).strip()
     modfn = expander(invoke_args[1]).strip()


### PR DESCRIPTION
While attempting to parse out the Simple English wiktionary (related to #4), I hit errors in Lua when executing templates. The issue was that Wikipedia uses Lua 5.1 everywhere, and Lua 5.3 removed some functions from `table`. In this PR I only polyfill `table.maxn`, though it's possible we will encounter a few others in the future. This allows us to parse the Simple English wiktionary without errors.