### PR TITLE
Ban poison module

### DIFF
--- a/wikitextprocessor/lua/_sandbox_phase1.lua
+++ b/wikitextprocessor/lua/_sandbox_phase1.lua
@@ -22,6 +22,10 @@ local _orig_package = package
 -- data file, and returns its initialization function.  This caches the
 -- initialization function.
 function new_loader(modname)
+   -- this module wreaks havoc on the global namespace
+   if modname == "Module:No globals" then
+      return nil, "Module banned"
+   end
    -- print("lua new_loader: " .. modname)
    -- If the module is in the normal cache (loaded by require), call its
    -- intialization function

--- a/wikitextprocessor/lua/_sandbox_phase2.lua
+++ b/wikitextprocessor/lua/_sandbox_phase2.lua
@@ -181,7 +181,7 @@ local function _lua_invoke(mod_name, fn_name, frame, page_title, timeout)
             if not success then
                _mw_frame = saved_frame
                _mw_pageTitle = saved_pageTitle
-               return False, ("\tLoading module failed in #invoke: " ..
+               return false, ("\tLoading module failed in #invoke: " ..
                                  mod1 .. "\n" .. mod)
             end
             _save_mod(mod1, mod)
@@ -197,7 +197,7 @@ local function _lua_invoke(mod_name, fn_name, frame, page_title, timeout)
             if not success then
                _mw_frame = saved_frame
                _mw_pageTitle = saved_pageTitle
-               return False, ("\tLoading module failed in #invoke: " ..
+               return false, ("\tLoading module failed in #invoke: " ..
                                  mod_name .. "\n" .. mod)
             end
             _save_mod(mod_name, mod)

--- a/wikitextprocessor/luaexec.py
+++ b/wikitextprocessor/luaexec.py
@@ -377,6 +377,24 @@ def call_lua_sandbox(ctx, invoke_args, expander, parent, timeout):
     ctx.lua_depth += 1
     lua = ctx.lua
 
+    # Wikipedia uses Lua 5.1, and lupa uses 5.4. Some methods
+    # were removed between now and then, so we need this polyfill:
+    lua.execute(
+"""
+table.maxn = function(tab)
+if type(tab) ~= 'table' then
+    error('table.maxn param #1 tab expect "table", got "' .. type(tab) .. '"', 2)
+end
+local length = 0
+for k in pairs(tab) do
+    if type(k) == 'number' and length < k and math.floor(k) == k then
+    length = k
+    end
+end
+return length
+end
+""")
+
     # Get module and function name
     modname = expander(invoke_args[0]).strip()
     modfn = expander(invoke_args[1]).strip()


### PR DESCRIPTION
On the theme of parsing the Simple English Wiktionary, either this module must be prevented from loading or else something must be done to prevent one module from changing the global namespace for templates loaded from other pages. See the commit message for more details.