### PR TITLE
Expand Chinese Wiktionary language and POS heading templates

### DIFF
--- a/wikitextprocessor/core.py
+++ b/wikitextprocessor/core.py
@@ -1285,6 +1285,24 @@ class Wtp:
                         if t2 is not None:
                             t = t2
 
+                    if self.lang_code == "zh" and name.startswith("-"):
+                        if "<h2>" in t:
+                            # https://zh.wiktionary.org/wiki/Template:-la-
+                            lang_heading = re.search(r"<h2>([^<]+)</h2>", t).group(1)
+                            t = f"=={lang_heading}=="
+                        elif "==" in t and " " in t:
+                            # https://zh.wiktionary.org/wiki/Template:-abbr-
+                            origin_heading = re.search(r"=+([^=]+)=+", t).group(1)
+                            heading = origin_heading.split()[-1]
+                            equal_sign_count = 0
+                            for char in origin_heading:
+                                if char == "=":
+                                    equal_sign_count += 1
+                                else:
+                                    break
+                            t = "=" * equal_sign_count
+                            t = t + heading + t
+
                     assert isinstance(t, str)
                     self.expand_stack.pop()  # template name
                     parts.append(t)

--- a/wikitextprocessor/core.py
+++ b/wikitextprocessor/core.py
@@ -379,7 +379,7 @@ class Wtp:
             return self.rev_ht[v]
         idx = len(self.cookies)
         if idx >= MAX_MAGICS:
-            ctx.error("too many templates, arguments, or parser function calls")
+            self.error("too many templates, arguments, or parser function calls")
             return ""
         self.cookies.append(v)
         ch = chr(MAGIC_FIRST + idx)
@@ -634,12 +634,15 @@ class Wtp:
         body = self._template_to_body(title, text)
         assert isinstance(body, str)
         self.templates[name] = body
+        if self.lang_code == "zh":
+            self.add_chinese_lower_case_template(name, body)
+
+    def add_chinese_lower_case_template(self, name, body):
         # Chinese Wiktionary capitalizes the first letter of template name
         # in template pages but uses lower case in word pages
-        if self.lang_code == "zh":
-            lower_case_name = name[0].lower() + name[1:]
-            if lower_case_name not in self.templates:
-                self.templates[lower_case_name] = body
+        lower_case_name = name[0].lower() + name[1:]
+        if lower_case_name not in self.templates:
+            self.templates[lower_case_name] = body
 
     def _analyze_template(self, name, body):
         """Analyzes a template body and returns a set of the canonicalized
@@ -803,6 +806,9 @@ class Wtp:
             self.templates[k] = self.templates[v]
             if v in self.need_pre_expand:
                 self.need_pre_expand.add(k)
+            if self.lang_code == "zh":
+                self.add_chinese_lower_case_template(k, self.templates[v])
+
 
         # Save cache data
         if self.cache_file is not None and not self.cache_file_old:
@@ -1158,8 +1164,6 @@ class Wtp:
                     if name not in all_templates:
                         # XXX tons of these in enwiktionary-20201201 ???
                         #self.debug("undefined template {!r}.format(tname))
-                        print(name)
-                        print(html.escape(name))
                         parts.append('<strong class="error">Template:{}'
                                      '</strong>'
                                      .format(html.escape(name)))


### PR DESCRIPTION
Some Chinese Wiktionary pages use templates for language and POS section headers([Category:语言模板](https://zh.wiktionary.org/wiki/Category:%E8%AF%AD%E8%A8%80%E6%A8%A1%E6%9D%BF), [Category:詞類模板](https://zh.wiktionary.org/wiki/Category:%E8%A9%9E%E9%A1%9E%E6%A8%A1%E6%9D%BF)). This pull request adds these templates to `Wtp.need_pre_expand`, so they can be expanded before calling `fix_subtitle_hierarchy()`at [here](https://github.com/tatuylonen/wiktextract/blob/093b6892431f1a8e796b18d17fbd8197e74ad0ba/wiktextract/page.py#L2830).