### PR TITLE
Treate URL in template argument as plain text

### DIFF
--- a/wikitextprocessor/parser.py
+++ b/wikitextprocessor/parser.py
@@ -1632,6 +1632,10 @@ def token_iter(ctx, text):
                     for x in token_iter(ctx, m.group(2)):
                         yield x
                     yield True, ">" + m.group(4)
+                elif start > 0 and part[start - 1] == "=" and token.startswith(("https://", "http://")):
+                    # treat URL in template argument as plain text
+                    # otherwise it'll be converted to wikitext link: [url]
+                    yield False, token
                 else:
                     yield True, token
             if pos != len(part):


### PR DESCRIPTION
Fix `archivedate` argument not included error in Module:quote(https://en.wiktionary.org/wiki/Module:quote). This error is caused by the parser treats the URL argument as external link and later converts the URL to wikitext link(`node_expand.to_html()`) in the `[url]` form with breaks the Lua code.

Module:quote checks the URL argument, if the URL starts with `https://web.archive.org/web/` then the `archivedate` argument is not required. But since the arguemnt now starts with `[https://`, it throws an error.

Example page: https://en.wiktionary.org/wiki/accent

wikitext:
```
##* {{quote-web|en|archiveurl=https://web.archive.org/web/20221219212008/https://www.newyorker.com/news/news-desk/terror-strikes-in-paris|work={{w|The New Yorker}}|passage=They were all Middle Eastern types but spoke French without any '''accent'''.|title=Terror Strikes in Paris|date=2015-11-14|author={{w|Adam Gopnik}}|quotee=Célia}}
```
Python variables:
`part`: "archiveurl=https://web.archive.org/web/20221219212008/https://www.newyorker.com/news/news-desk/terror-strikes-in-paris"
`token`: "https://web.archive.org/web/20221219212008/https://www.newyorker.com/news/news-desk/terror-strikes-in-paris"