### PR TITLE
Fix 'str' object has no attribute 'warning' error when `extensionTag()` creates not allowed HTML tag.

### DIFF
--- a/tests/test_wikiprocess.py
+++ b/tests/test_wikiprocess.py
@@ -2253,6 +2253,10 @@ return export
         self.scribunto("<br />", """
         return frame:extensionTag("br")""")
 
+    def test_frame_extensionTag5(self):
+        self.scribunto("{{#tag:not_allowed_tag|}}", """
+        return frame:extensionTag("not_allowed_tag")""")
+
     def test_frame_newChild1(self):
         self.scribunto("", """
         return frame:newChild():getTitle()""")

--- a/wikitextprocessor/luaexec.py
+++ b/wikitextprocessor/luaexec.py
@@ -424,7 +424,7 @@ def call_lua_sandbox(ctx, invoke_args, expander, parent, timeout):
                 attrs = [attrs]
 
             ctx.expand_stack.append("extensionTag()")
-            ret = tag_fn(title, "#tag", [name, content] + attrs,
+            ret = tag_fn(ctx, "#tag", [name, content] + attrs,
                          lambda x: x)  # Already expanded
             ctx.expand_stack.pop()
             # Expand any templates from the result

--- a/wikitextprocessor/parserfns.py
+++ b/wikitextprocessor/parserfns.py
@@ -8,6 +8,10 @@ import math
 import datetime
 import urllib.parse
 import dateparser
+
+from typing import List
+from collections.abc import Callable
+
 from .wikihtml import ALLOWED_HTML_TAGS
 from .common import nowiki_quote, MAGIC_NOWIKI_CHAR
 
@@ -150,7 +154,7 @@ def lst_fn(ctx, fn_name, args, expander):
     return "".join(parts)
 
 
-def tag_fn(ctx, fn_name, args, expander):
+def tag_fn(ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]) -> str:
     """Implements #tag parser function."""
     tag = expander(args[0]).lower() if args else ""
     if tag not in ALLOWED_HTML_TAGS and tag != "nowiki":


### PR DESCRIPTION
I saw the [error](https://kaikki.org/dictionary/errors/details--str--object-has-no-attribute--warning-I68s8lEm.html#LUA-error-in--invoke---translations----show---parent---Template-t----1---lv---2---vilnis---3---m---) on kaikki.org. I can't reproduce the error on the `wave` page but the first argument of `tag_fn()` should be `Wtp` object.