### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{py,lua}]
+indent_style = space
+indent_size = 4
+max_line_length = 80


### PR DESCRIPTION
Add [EditorConfig](https://editorconfig.org) file.

For Emacs, the following code can be added to .emacs file to enable [editorconfig-mode](https://github.com/editorconfig/editorconfig-emacs) and [global-display-fill-column-indicator-mode](https://www.gnu.org/software/emacs/manual/html_node/emacs/Displaying-Boundaries.html):

```
(editorconfig-mode 1)
(setq column-number-mode t)
(global-display-fill-column-indicator-mode)
```

And for formatting code, we can use [black](https://github.com/psf/black). I'd recommend use black's default line length([88](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length)) so we don't have to configure black and [black's doc](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#configuration-via-a-file) also recommend use the default configuration.

[ruff](https://beta.ruff.rs/docs) can be used to check line length, it also uses black's line length by default.