### PR TITLE
Save extarcted pages to files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "dateparser",
     "lupa @ git+https://github.com/scoder/lupa.git",
     "lxml",
+    "requests",
 ]
 
 [project.optional-dependencies]

--- a/wikitextprocessor/dumpparser.py
+++ b/wikitextprocessor/dumpparser.py
@@ -2,7 +2,9 @@
 #
 # Copyright (c) 2018-2022 Tatu Ylonen.  See file LICENSE and https://ylonen.org
 
+import hashlib
 import logging
+import os
 import shutil
 import subprocess
 import sys
@@ -12,7 +14,11 @@ from pathlib import Path
 from typing import Optional, Set, List
 
 
-def process_input(path: str, page_cb: Callable[[str, str], None], namespace_ids: Set[int]) -> None:
+def process_input(
+    path: str,
+    page_cb: Callable[[str, str], None],
+    namespace_ids: Set[int],
+) -> None:
     """Processes the entire input once, calling chunk_fn for each chunk.
     A chunk is a list of data, where ``data`` is a dict
     containing at least "title" and "text" keys.  This returns a list
@@ -24,7 +30,9 @@ def process_input(path: str, page_cb: Callable[[str, str], None], namespace_ids:
     from lxml import etree
 
     if path.endswith(".bz2"):
-        bzcat_command = "lbzcat" if shutil.which("lbzcat") is not None else "bzcat"
+        bzcat_command = (
+            "lbzcat" if shutil.which("lbzcat") is not None else "bzcat"
+        )
         subp = subprocess.Popen([bzcat_command, path], stdout=subprocess.PIPE)
         wikt_f = subp.stdout
     else:
@@ -34,17 +42,27 @@ def process_input(path: str, page_cb: Callable[[str, str], None], namespace_ids:
     namespaces = {None: namespace_str}
 
     page_nums = 0
-    for _, page_element in etree.iterparse(wikt_f, tag=f"{{{namespace_str}}}page"):
+    for _, page_element in etree.iterparse(
+        wikt_f, tag=f"{{{namespace_str}}}page"
+    ):
         title = page_element.findtext("title", "", namespaces)
         namespace_id = int(page_element.findtext("ns", "0", namespaces))
-        if namespace_id not in namespace_ids or title.endswith("/documentation") or "/testcases" in title:
+        if (
+            namespace_id not in namespace_ids
+            or title.endswith("/documentation")
+            or "/testcases" in title
+        ):
             page_element.clear(keep_tail=True)
             continue
 
         text = None
         redirect_to = None
         model = page_element.findtext("revision/model", "", namespaces)
-        if (redirect_element := page_element.find("redirect", namespaces=namespaces)) is not None:
+        if (
+            redirect_element := page_element.find(
+                "redirect", namespaces=namespaces
+            )
+        ) is not None:
             redirect_to = redirect_element.get("title", "")
         else:
             if model not in {"wikitext", "Scribunto", "json"}:
@@ -53,7 +71,9 @@ def process_input(path: str, page_cb: Callable[[str, str], None], namespace_ids:
                 continue
             text = page_element.findtext("revision/text", "", namespaces)
 
-        page_cb(title, namespace_id, body=text, redirect_to=redirect_to, model=model)
+        page_cb(
+            title, namespace_id, body=text, redirect_to=redirect_to, model=model
+        )
         page_element.clear(keep_tail=True)
         page_nums += 1
         if page_nums % 10000 == 0:
@@ -62,9 +82,15 @@ def process_input(path: str, page_cb: Callable[[str, str], None], namespace_ids:
     wikt_f.close()
 
 
-def process_dump(ctx: "Wtp", path: str, namespace_ids: Set[int],
-                 overwrite_folders: Optional[List[Path]] = None, skip_extract_dump: bool = False,
-                 page_handler: Optional[Callable[[str, int], None]] = None) -> None:
+def process_dump(
+    ctx: "Wtp",
+    path: str,
+    namespace_ids: Set[int],
+    overwrite_folders: Optional[List[Path]] = None,
+    skip_extract_dump: bool = False,
+    page_handler: Optional[Callable[[str, int], None]] = None,
+    save_pages_path: Optional[Path] = None,
+) -> None:
     """Parses a WikiMedia dump file ``path`` (which should point to a
     "<project>-<date>-pages-articles.xml.bz2" file.  This implements
     the first phase of processing a dump - copying it to a temporary
@@ -74,13 +100,24 @@ def process_dump(ctx: "Wtp", path: str, namespace_ids: Set[int],
     # Run Phase 1 in a single thread; this mostly just extracts pages into
     # a temporary file.
     if not skip_extract_dump:
-        process_input(path, page_handler if page_handler is not None else ctx.add_page, namespace_ids)
+        process_input(
+            path,
+            page_handler if page_handler is not None else ctx.add_page,
+            namespace_ids,
+        )
+        if save_pages_path is not None:
+            save_pages_to_file(ctx, save_pages_path)
+
     if overwrite_folders is not None:
         overwrite_pages(ctx, overwrite_folders)
 
     # Analyze which templates should be expanded before parsing
-    if not skip_extract_dump or (skip_extract_dump and overwrite_folders is not None):
-        logging.info("Analyzing which templates should be expanded before parsing")
+    if not skip_extract_dump or (
+        skip_extract_dump and overwrite_folders is not None
+    ):
+        logging.info(
+            "Analyzing which templates should be expanded before parsing"
+        )
         ctx.analyze_templates()
 
 
@@ -91,15 +128,41 @@ def overwrite_pages(ctx: "Wtp", folder_paths: List[Path]) -> None:
                 first_line = f.readline()
                 if not first_line.startswith("TITLE: "):
                     logging.error(
-                        'First line of file supplied with --override must be "TITLE: <page title>"'
-                        '(The page title for this would normally start with Module:')
+                        "First line of file supplied with --override must be "
+                        '"TITLE: <page title>" (The page title for this would '
+                        "normally start with Module:"
+                    )
                     sys.exit(1)
                 title = first_line[7:].strip()
-                local_ns_name = title[:title.find(":")]
+                local_ns_name = title[: title.find(":")]
                 ns_id = ctx.NS_ID_BY_LOCAL_NAME.get(local_ns_name, 0)
                 module_ns_id = ctx.NAMESPACE_DATA.get("Module", {}).get("id")
                 model = "Scribunto" if ns_id == module_ns_id else "wikitext"
                 ctx.add_page(title, ns_id, f.read(), model=model)
+
+
+def save_pages_to_file(ctx: "Wtp", directory: Path) -> None:
+    for page in ctx.get_all_pages():
+        title = page.title.replace("//", "__slashslash__")
+        if ".." in title:
+            title = title.replace(".", "__dot__")
+        if page.namespace_id == 0:
+            file_path = directory.joinpath(f"Words/{title}.txt")
+        else:
+            file_path = directory.joinpath(f'{title.replace(":", "/", 1)}.txt')
+
+        if len(file_path.name.encode()) > os.pathconf("/", "PC_NAME_MAX"):
+            file_path = file_path.with_stem(
+                file_path.stem[:50]
+                + "_"
+                + hashlib.sha256(file_path.stem.encode("utf-8")).hexdigest()
+            )
+
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        with file_path.open("w", encoding="utf-8") as f:
+            f.write(f"TITLE: {page.title}\n")
+            f.write(page.body if page.body is not None else page.redirect_to)
+
 
 # XXX parse <namespaces> and use that in both Python and Lua code
 

--- a/wikitextprocessor/lua/_sandbox_phase2.lua
+++ b/wikitextprocessor/lua/_sandbox_phase2.lua
@@ -20,6 +20,8 @@ mw_python_get_page_info = nil
 mw_python_get_page_content = nil
 mw_python_fetch_language_name = nil
 mw_python_fetch_language_names = nil
+mw_wikibase_getlabel_python = nil
+mw_wikibase_getdesc_python = nil
 
 -- These are used for passing information about the current call to
 -- _lua_invoke().  The values are restred on return, as calls can be
@@ -195,10 +197,11 @@ end
 -- Python function that will be used for loading Lua modules and various
 -- other Python functions that implement some of the functionality needed
 -- for executing Scribunto code (these functions are called from Lua code).
-local function _lua_set_functions(mw_text_decode, mw_text_encode,
-                                  mw_text_jsonencode, mw_text_jsondecode,
-                                  get_page_info, get_page_content,
-                                  fetch_language_name, fetch_language_names)
+local function _lua_set_functions(
+        mw_text_decode, mw_text_encode, mw_text_jsonencode, mw_text_jsondecode,
+        get_page_info, get_page_content, fetch_language_name,
+        fetch_language_names, mw_wikibase_getlabel, mw_wikibase_getdesc
+)
    -- Note: this is exposed to the Lua sandbox and the Lua sandbox can access
    -- the functions via mw.  Thus all the Python functions provided here
    -- must be safe to call from hostile code.
@@ -211,6 +214,8 @@ local function _lua_set_functions(mw_text_decode, mw_text_encode,
    mw_python_get_page_content = get_page_content
    mw_python_fetch_language_name = fetch_language_name
    mw_python_fetch_language_names = fetch_language_names
+   mw_wikibase_getlabel_python = mw_wikibase_getlabel
+   mw_wikibase_getdesc_python = mw_wikibase_getdesc
 end
 
 

--- a/wikitextprocessor/lua/_sandbox_phase2.lua
+++ b/wikitextprocessor/lua/_sandbox_phase2.lua
@@ -34,7 +34,13 @@ local function frame_args_index(new_args, key)
       key = i
    end
    local v = new_args._orig[key]
-   if v == nil then return nil end
+   if v == nil then
+       -- "inf" got converted to number type, convert back to string
+       v = new_args._orig[tostring(key)]
+       if v == nil then
+           return nil
+       end
+   end
    if not new_args._preprocessed[key] then
       local frame = new_args._frame
       v = frame:preprocess(v)
@@ -230,14 +236,14 @@ end
 function ipairs(t)
     local mt = getmetatable(t)
     if mt and mt.__ipairs then
-       return mt.__ipairs(t)
+        return mt.__ipairs(t)
     else
-       local function stateless_iter(tbl, i)
-	  i = i + 1
-	  local v = tbl[i]
-	  if nil~=v then return i, v end
-       end
-       return stateless_iter, t, 0
+        local function stateless_iter(tbl, i)
+            i = i + 1
+            local v = tbl[i]
+            if nil~=v then return i, v end
+        end
+        return stateless_iter, t, 0
     end
 end
 

--- a/wikitextprocessor/lua/mw_wikibase.lua
+++ b/wikitextprocessor/lua/mw_wikibase.lua
@@ -19,7 +19,7 @@ function mw_wikibase.getEntityUrl(id)
 end
 
 function mw_wikibase.getLabel(id)
-   return nil
+    return mw_wikibase_getlabel_python(id)
 end
 
 function mw_wikibase.getLabelWithLang(id)
@@ -35,7 +35,7 @@ function mw_wikibase.getSitelink(id, globalSiteId)
 end
 
 function mw_wikibase.getDescription(id)
-   return nil
+    return mw_wikibase_getdesc_python(id)
 end
 
 function mw_wikibase.getDescriptionWithLang(id)

--- a/wikitextprocessor/luaexec.py
+++ b/wikitextprocessor/luaexec.py
@@ -6,6 +6,7 @@
 import copy
 import os
 import re
+import functools
 import html
 import json
 import traceback
@@ -21,15 +22,14 @@ from .parserfns import PARSER_FUNCTIONS, call_parser_function, tag_fn
 builtin_lua_search_paths = [
     # [path, ignore_modules]
     [".", ["string", "debug"]],
-    ["mediawiki-extensions-Scribunto/includes/engines/LuaCommon/lualib",
-     []],
+    ["mediawiki-extensions-Scribunto/includes/engines/LuaCommon/lualib", []],
 ]
 
 # Determine which directory our data files are in
 lua_dir = pkg_resources.resource_filename("wikitextprocessor", "lua/")
 if not lua_dir.endswith("/"):
     lua_dir += "/"
-#print("lua_dir", lua_dir)
+# print("lua_dir", lua_dir)
 
 
 def lua_loader(ctx: "Wtp", modname: str) -> Optional[str]:
@@ -44,7 +44,7 @@ def lua_loader(ctx: "Wtp", modname: str) -> Optional[str]:
     ns_prefix = ns_data["name"] + ":"
     ns_alias_prefixes = tuple(alias + ":" for alias in ns_data["aliases"])
     if modname.startswith(ns_alias_prefixes):
-        modname = ns_prefix + modname[modname.find(":") + 1:]
+        modname = ns_prefix + modname[modname.find(":") + 1 :]
 
     # Local name usually not used in Lua code
     if modname.startswith(("Module:", ns_prefix)):
@@ -62,9 +62,9 @@ def lua_loader(ctx: "Wtp", modname: str) -> Optional[str]:
         path = re.sub(r"[\0-\037]", "", path)  # Remove control chars, e.g. \n
         path = path.replace(":", "/")
         path = path.replace(" ", "_")
-        path = re.sub(r"//+", "/", path)    # Replace multiple slashes by one
+        path = re.sub(r"//+", "/", path)  # Replace multiple slashes by one
         path = re.sub(r"\.\.+", ".", path)  # Replace .. and longer by .
-        path = re.sub(r"^//+", "", path)    # Remove initial slashes
+        path = re.sub(r"^//+", "", path)  # Remove initial slashes
         path += ".lua"
         data = None
         for prefix, exceptions in builtin_lua_search_paths:
@@ -89,7 +89,7 @@ def mw_text_decode(text, decodeNamedEntities):
     pos = 0
     for m in re.finditer(r"&(lt|gt|amp|quot|nbsp);", text):
         if pos < m.start():
-            parts.append(text[pos:m.start()])
+            parts.append(text[pos : m.start()])
         pos = m.end()
         tag = m.group(1)
         if tag == "lt":
@@ -231,27 +231,31 @@ def fetch_language_names(ctx, include):
 
 def call_set_functions(ctx, set_functions):
     # Set functions that are implemented in Python
-    set_functions(mw_text_decode,
-                  mw_text_encode,
-                  mw_text_jsonencode,
-                  lambda x, *rest:
-                  mw_text_jsondecode(ctx, x, *rest),
-                  lambda x: get_page_info(ctx, x),
-                  lambda x: get_page_content(ctx, x),
-                  lambda x: fetch_language_name(ctx, x),
-                  lambda x: fetch_language_names(ctx, x))
+    set_functions(
+        mw_text_decode,
+        mw_text_encode,
+        mw_text_jsonencode,
+        lambda x, *rest: mw_text_jsondecode(ctx, x, *rest),
+        lambda x: get_page_info(ctx, x),
+        lambda x: get_page_content(ctx, x),
+        lambda x: fetch_language_name(ctx, x),
+        lambda x: fetch_language_names(ctx, x),
+        mw_wikibase_getlabel,
+        mw_wikibase_getdescription,
+    )
 
 
 def initialize_lua(ctx):
-
     def filter_attribute_access(obj, attr_name, is_setting):
         if isinstance(attr_name, str) and not attr_name.startswith("_"):
             return attr_name
         raise AttributeError("access denied")
 
-    lua = lupa.LuaRuntime(unpack_returned_tuples=True,
-                          register_eval=False,
-                          attribute_filter=filter_attribute_access)
+    lua = lupa.LuaRuntime(
+        unpack_returned_tuples=True,
+        register_eval=False,
+        attribute_filter=filter_attribute_access,
+    )
     ctx.lua = lua
     set_namespace_data = lua.eval("function(v) NAMESPACE_DATA = v end")
     lua_namespace_data = copy.deepcopy(ctx.NAMESPACE_DATA)
@@ -259,7 +263,9 @@ def initialize_lua(ctx):
         for k, v in ns_data.items():
             if isinstance(v, list):
                 lua_namespace_data[ns_name][k] = lua.table_from(v)
-        lua_namespace_data[ns_name] = lua.table_from(lua_namespace_data[ns_name])
+        lua_namespace_data[ns_name] = lua.table_from(
+            lua_namespace_data[ns_name]
+        )
     set_namespace_data(lua.table_from(lua_namespace_data))
 
     # Load Lua sandbox Phase 1.  This is a very minimal file that only sets
@@ -297,11 +303,11 @@ def call_lua_sandbox(ctx, invoke_args, expander, parent, timeout):
     #       .format(ctx.title, invoke_args, parent))
 
     if len(invoke_args) < 2:
-        ctx.debug("#invoke {} with too few arguments"
-                  .format(invoke_args),
-                  sortid="luaexec/369")
-        return ("{{" + invoke_args[0] + ":" +
-                "|".join(invoke_args[1:]) + "}}")
+        ctx.debug(
+            "#invoke {} with too few arguments".format(invoke_args),
+            sortid="luaexec/369",
+        )
+        return "{{" + invoke_args[0] + ":" + "|".join(invoke_args[1:]) + "}}"
 
     # Initialize the Lua sandbox if not already initialized
     if ctx.lua_depth == 0:
@@ -374,8 +380,10 @@ def call_lua_sandbox(ctx, invoke_args, expander, parent, timeout):
 
         def extensionTag(frame, *args):
             if len(args) < 1:
-                ctx.debug("lua extensionTag with missing arguments",
-                          sortid="luaexec/464")
+                ctx.debug(
+                    "lua extensionTag with missing arguments",
+                    sortid="luaexec/464",
+                )
                 return ""
             dt = args[0]
             if not isinstance(dt, (str, int, float, type(None))):
@@ -395,20 +403,21 @@ def call_lua_sandbox(ctx, invoke_args, expander, parent, timeout):
                 content = str(args[1] or "")
                 attrs = args[2] or {}
             if not isinstance(attrs, str):
-                attrs = list(v if isinstance(k, int) else
-                             '{}="{}"'
-                             .format(k, html.escape(v, quote=True))
-                             for k, v in
-                             sorted(attrs.items(),
-                                    key=lambda x: str(x[0])))
+                attrs = list(
+                    v
+                    if isinstance(k, int)
+                    else '{}="{}"'.format(k, html.escape(v, quote=True))
+                    for k, v in sorted(attrs.items(), key=lambda x: str(x[0]))
+                )
             elif not attrs:
                 attrs = []
             else:
                 attrs = [attrs]
 
             ctx.expand_stack.append("extensionTag()")
-            ret = tag_fn(ctx, "#tag", [name, content] + attrs,
-                         lambda x: x)  # Already expanded
+            ret = tag_fn(
+                ctx, "#tag", [name, content] + attrs, lambda x: x
+            )  # Already expanded
             ctx.expand_stack.pop()
             # Expand any templates from the result
             ret = preprocess(frame, ret)
@@ -416,8 +425,9 @@ def call_lua_sandbox(ctx, invoke_args, expander, parent, timeout):
 
         def callParserFunction(frame, *args):
             if len(args) < 1:
-                ctx.debug("lua callParserFunction missing name",
-                          sortid="luaexec/506")
+                ctx.debug(
+                    "lua callParserFunction missing name", sortid="luaexec/506"
+                )
                 return ""
             name = args[0]
             if not isinstance(name, str):
@@ -434,14 +444,15 @@ def call_lua_sandbox(ctx, invoke_args, expander, parent, timeout):
                 if isinstance(arg, (int, float, str)):
                     new_args.append(str(arg))
                 else:
-                    for k, v in sorted(arg.items(),
-                                       key=lambda x: str(x[0])):
+                    for k, v in sorted(arg.items(), key=lambda x: str(x[0])):
                         new_args.append(str(v))
             name = ctx._canonicalize_parserfn_name(name)
             if name not in PARSER_FUNCTIONS:
-                ctx.debug("lua frame callParserFunction() undefined "
-                          "function {!r}"
-                          .format(name), sortid="luaexec/529")
+                ctx.debug(
+                    "lua frame callParserFunction() undefined "
+                    "function {!r}".format(name),
+                    sortid="luaexec/529",
+                )
                 return ""
             return call_parser_function(ctx, name, new_args, lambda x: x)
 
@@ -455,8 +466,9 @@ def call_lua_sandbox(ctx, invoke_args, expander, parent, timeout):
 
         def preprocess(frame, *args):
             if len(args) < 1:
-                ctx.debug("lua preprocess missing argument",
-                          sortid="luaexec/545")
+                ctx.debug(
+                    "lua preprocess missing argument", sortid="luaexec/545"
+                )
                 return ""
             v = args[0]
             if not isinstance(v, str):
@@ -471,13 +483,16 @@ def call_lua_sandbox(ctx, invoke_args, expander, parent, timeout):
 
         def expandTemplate(frame, *args):
             if len(args) < 1:
-                ctx.debug("lua expandTemplate missing arguments",
-                          sortid="luaexec/561")
+                ctx.debug(
+                    "lua expandTemplate missing arguments", sortid="luaexec/561"
+                )
                 return ""
             dt = args[0]
             if isinstance(dt, (int, float, str, type(None))):
-                ctx.debug("lua expandTemplate arguments should be named",
-                          sortid="luaexec/566")
+                ctx.debug(
+                    "lua expandTemplate arguments should be named",
+                    sortid="luaexec/566",
+                )
                 return ""
             title = dt["title"] or ""
             args = dt["args"] or {}
@@ -502,10 +517,12 @@ def call_lua_sandbox(ctx, invoke_args, expander, parent, timeout):
         frame["getTitle"] = lambda ctx: title
         frame["preprocess"] = preprocess
         # XXX still untested:
-        frame["newParserValue"] = \
-            lambda ctx, x: value_with_expand(ctx, "preprocess", x)
-        frame["newTemplateParserValue"] = \
-            lambda ctx, x: value_with_expand(ctx, "expand", x)
+        frame["newParserValue"] = lambda ctx, x: value_with_expand(
+            ctx, "preprocess", x
+        )
+        frame["newTemplateParserValue"] = lambda ctx, x: value_with_expand(
+            ctx, "expand", x
+        )
         # newChild set in sandbox.lua
         return lua.table_from(frame)
 
@@ -536,9 +553,12 @@ def call_lua_sandbox(ctx, invoke_args, expander, parent, timeout):
         else:
             ok, text = ret[0], ret[1]
     except UnicodeDecodeError:
-        ctx.debug("invalid unicode returned from lua by {}: parent {}"
-                  .format(invoke_args, parent),
-                  sortid="luaexec/626")
+        ctx.debug(
+            "invalid unicode returned from lua by {}: parent {}".format(
+                invoke_args, parent
+            ),
+            sortid="luaexec/626",
+        )
         ok, text = True, ""
     except lupa.LuaError as e:
         ok, text = False, e
@@ -558,9 +578,9 @@ def call_lua_sandbox(ctx, invoke_args, expander, parent, timeout):
         parts = [str(text)]
         # traceback.format_exception does not have a named keyvalue etype=
         # anymore, in latest Python versions it is positional only.
-        lst = traceback.format_exception(type(text),
-                                         value=text,
-                                         tb=text.__traceback__)
+        lst = traceback.format_exception(
+            type(text), value=text, tb=text.__traceback__
+        )
         for x in lst:
             parts.append("\t" + x.strip())
         text = "\n".join(parts)
@@ -574,22 +594,66 @@ def call_lua_sandbox(ctx, invoke_args, expander, parent, timeout):
         # Ignore this error - it is an error but a clear error in Wiktionary
         # rather than in the extractor.
         return ""
-    elif "attempt to index a nil value (local 'lang')" in text and \
-         "in function 'Module:links.getLinkPage'" in text:
+    elif (
+        "attempt to index a nil value (local 'lang')" in text
+        and "in function 'Module:links.getLinkPage'" in text
+    ):
         # Ignore this error - happens when an unknown language code is passed
         # to various templates (a Wiktionary error, not extractor error)
         return ""
     else:
         if "check deprecated lang param usage" in ctx.expand_stack:
-            ctx.debug("LUA error but likely not bug -- in #invoke {} parent {}"
-                      .format(invoke_args, parent),
-                      trace=text, sortid="luaexec/679")
+            ctx.debug(
+                "LUA error but likely not bug -- in #invoke {} parent {}".format(
+                    invoke_args, parent
+                ),
+                trace=text,
+                sortid="luaexec/679",
+            )
         else:
-            ctx.error("LUA error in #invoke {} parent {}"
-                      .format(invoke_args, parent),
-                      trace=text, sortid="luaexec/683")
+            ctx.error(
+                "LUA error in #invoke {} parent {}".format(invoke_args, parent),
+                trace=text,
+                sortid="luaexec/683",
+            )
     msg = "Lua execution error"
     if "Lua timeout error" in text:
         msg = "Lua timeout error"
-    return ('<strong class="error">{} in Module:{} function {}'
-            '</strong>'.format(msg, html.escape(modname), html.escape(modfn)))
+    return (
+        '<strong class="error">{} in Module:{} function {}'
+        "</strong>".format(msg, html.escape(modname), html.escape(modfn))
+    )
+
+
+@functools.cache
+def query_wikidata(item_id: str):
+    import requests
+
+    r = requests.get(
+        "https://query.wikidata.org/sparql",
+        params={
+            "query": "SELECT ?itemLabel ?itemDescription WHERE { VALUES ?item "
+            + f"{{ wd:{item_id} }}. "
+            + "SERVICE wikibase:label { bd:serviceParam wikibase:language"
+            + ' "[AUTO_LANGUAGE],en". }}',
+            "format": "json",
+        },
+        headers={"user-agent": "wikitextprocessor"},
+    )
+
+    if r.ok:
+        result = r.json()
+        for binding in result.get("results", {}).get("bindings", []):
+            return binding
+    else:
+        return None
+
+
+def mw_wikibase_getlabel(item_id: str) -> str:
+    item_data = query_wikidata(item_id)
+    return item_data.get("itemLabel", {}).get("value", item_id)
+
+
+def mw_wikibase_getdescription(item_id: str) -> str:
+    item_data = query_wikidata(item_id)
+    return item_data.get("itemDescription", {}).get("value", item_id)


### PR DESCRIPTION
`Wtp.reprocess()` filters unused pages. In order to save all extracted pages, run the save files code inside `process_dump()`. Fixes #47 

Most changes to the `core.py` are formatting code made by [black](https://github.com/psf/black).

Opening and writing millions of files are slow, it takes ten minutes to create extracted pages. I'd discourage the usage of the `--pages-dir` option, page text can be inspected by querying the database.

Also fixes these Lua errors:
- https://kaikki.org/dictionary/errors/details-module-not-found-----RQ-xum-TI----export---.html
- https://kaikki.org/dictionary/errors/details-With-part-of-speech--ger---must-specif-Q9nKZHOa.html and other `Module:it-form of` errors.
- https://kaikki.org/dictionary/errors/details-attempt-to-concatenate-local--link---a-3wtv07QZ.html#LUA-error-in--invoke---coinage----coinage---parent---Template-coin----1---en---2---Q131761----in----1808---