### PR TITLE
Don't convert table key "inf" and "nan" to number

### DIFF
--- a/wikitextprocessor/lua/_sandbox_phase2.lua
+++ b/wikitextprocessor/lua/_sandbox_phase2.lua
@@ -32,16 +32,12 @@ _mw_pageTitle = "<unassigned>"
 local function frame_args_index(new_args, key)
    -- print("frame_args_index", key)
    local i = tonumber(key)
-   if i ~= nil then
+   if key ~= "inf" and key ~= "nan" and i ~= nil then
       key = i
    end
    local v = new_args._orig[key]
    if v == nil then
-       -- "inf" got converted to number type, convert back to string
-       v = new_args._orig[tostring(key)]
-       if v == nil then
-           return nil
-       end
+       return nil
    end
    if not new_args._preprocessed[key] then
       local frame = new_args._frame


### PR DESCRIPTION
The previous code converts these string keys to their correspond "infinity" and "not a number" number value, that causes the `frame_args_index()` can't find the values of these keys.

This is the correct fix for those `inf` template parameters not found Lua errors. My previous commit https://github.com/tatuylonen/wikitextprocessor/commit/0726ce7deaca522df8b48ee5680a74eb486f68d2 works but not really fixes the error.