### PR TITLE
Don't skip whitespace token in `parser.token_iter()`

### DIFF
--- a/wikitextprocessor/parser.py
+++ b/wikitextprocessor/parser.py
@@ -1626,8 +1626,6 @@ def token_iter(ctx, text):
                     yield False, part[pos:start]
                 pos = m.end()
                 token = m.group(0)
-                if len(token.strip()) == 0:
-                    continue
                 if token.startswith("=="):
                     yield True, "<" + m.group(1)
                     for x in token_iter(ctx, m.group(2)):

--- a/wikitextprocessor/parser.py
+++ b/wikitextprocessor/parser.py
@@ -1539,8 +1539,9 @@ def token_iter(ctx, text):
             new_parts.append(tp)
         text = "".join(new_parts)
 
+    lines = re.split(r"(\n+)", text)  # Lines and separators
     parts_re = re.compile(r"('{2,})")
-    for line in text.splitlines():
+    for line in lines:
         parts = re.split(parts_re, line)
         state = 0  # 1=in italic 2=in bold 3=in both
         for i, part in enumerate(parts):


### PR DESCRIPTION
Previous commit eecb07352bc7eebc4924ed08d24b1d3fedce236a incorrectly added these two lines. This would cause the parser deletes the space between words. For example, page https://en.wiktionary.org/wiki/丫鬟 uses a `c=aa1 waan4` template parameter, but remove the whitespace would cause error in https://en.wiktionary.org/wiki/Module:yue-pron because it checks if the parameter matches "[0-9][a-z]" pattern.