### PR TITLE
Fix previous URL parser commit and a Lua error

### DIFF
--- a/wikitextprocessor/lua/mw_title.lua
+++ b/wikitextprocessor/lua/mw_title.lua
@@ -147,7 +147,9 @@ function mw_title.makeTitle(namespace, title, fragment, interwiki)
    if title:find("/%./") or title:find("/%.%./") then return nil end
    if title:sub(-2) == "/." or title:sub(-3) == "/.." then return nil end
    if #title > 255 then return nil end
-   if title:sub(1, 1) == " " or title:sub(-1) == " " then return nil end
+   if title:sub(1, 1) == " " or title:sub(-1) == " " then
+       title = title:gsub("^%s*(.-)%s*$", "%1")
+   end
    if title:find("  ") then return nil end
    if title:find("~~~~") then return nil end
    local prefixes = {

--- a/wikitextprocessor/parser.py
+++ b/wikitextprocessor/parser.py
@@ -1632,14 +1632,16 @@ def token_iter(ctx, text):
                     for x in token_iter(ctx, m.group(2)):
                         yield x
                     yield True, ">" + m.group(4)
-                elif (
-                    start > 0
-                    and part[start - 1] == "="
-                    and token.strip().startswith(("https://", "http://"))
-                ):
-                    # treat URL in template argument as plain text
-                    # otherwise it'll be converted to wikitext link: [url]
-                    yield False, token.strip()
+                elif token.strip().startswith(("https://", "http://")):
+                    if start > 0 and part[start - 1] == "=":
+                        # treat URL in template argument as plain text
+                        # otherwise it'll be converted to wikitext link: [url]
+                        yield False, token.strip()
+                    elif token.startswith(" "):
+                        yield True, token[:token.find("http")]
+                        yield True, token.strip()
+                    else:
+                        yield True, token
                 else:
                     yield True, token
             if pos != len(part):


### PR DESCRIPTION
The first commit fixes the error introduced from https://github.com/tatuylonen/wikitextprocessor/commit/eecb07352bc7eebc4924ed08d24b1d3fedce236a and pass the `test_url1` test.

The second commit fixes https://kaikki.org/dictionary/errors/details-attempt-to-index-a-nil-value-----links-rfq-IHVw.html