### PR TITLE
Clear `mw.loadData()` cache before processing each page

### DIFF
--- a/wikitextprocessor/core.py
+++ b/wikitextprocessor/core.py
@@ -103,7 +103,8 @@ class Wtp:
         "lua",  # Lua runtime or None if not yet initialized
         "lua_depth",  # Recursion depth in Lua calls
         "lua_invoke",  # Lua function used to invoke a Lua module
-        "lua_reset_env",  # Function to reset Lua environment
+        "lua_reset_env",  # Lua function to reset Lua environment
+        "lua_clear_loaddata_cache",  # Lua function to clear mw.loadData() cache
         "lua_path",  # Path to Lua modules
         "num_threads",  # Number of parallel threads to use
         "quiet",  # If True, don't print any messages during processing
@@ -155,6 +156,7 @@ class Wtp:
         self.lua = None
         self.lua_invoke = None
         self.lua_reset_env = None
+        self.lua_clear_loaddata_cache = None
         self.lua_depth = 0
         self.quiet = quiet
         self.rev_ht = {}
@@ -867,6 +869,8 @@ class Wtp:
         self.cookies = []
         self.rev_ht = {}
         self.expand_stack = [title]
+        if self.lua_clear_loaddata_cache is not None:
+            self.lua_clear_loaddata_cache()
 
     def start_section(self, title):
         """Starts processing a new section of the current page.  Calling this

--- a/wikitextprocessor/lua/_sandbox_phase1.lua
+++ b/wikitextprocessor/lua/_sandbox_phase1.lua
@@ -9,7 +9,7 @@ local _python_loader = nil
 local env = {}
 
 local loader_cache = {}
-local value_cache = {}
+local loaddata_cache = {}
 local _orig_package = package
 
 -- This function loads new a new module, whether built-in or defined in the
@@ -93,8 +93,8 @@ local function new_loadData(modname)
    -- If the module is in value cache (loaded by mw.loadData), just use its
    -- value as-is
    -- print("new_loadData", modname)
-   if value_cache[modname] ~= nil then
-      return value_cache[modname]
+   if loaddata_cache[modname] ~= nil then
+      return loaddata_cache[modname]
    end
    -- Load the module and create initialization function
    local fn, msg = new_loader(modname)
@@ -103,7 +103,7 @@ local function new_loadData(modname)
 
    -- If caching data (for mw.loadData), save the value.  This is kept
    -- across Lua environment resets.
-   value_cache[modname] = ret
+   loaddata_cache[modname] = ret
    return ret
 end
 
@@ -384,6 +384,10 @@ local function _lua_reset_env()
     return env
 end
 
+local function _clear_loadData_cache ()
+    loaddata_cache = {}
+end
+
 -- Switch to the sandbox environment
 assert(io ~= nil)  -- We should not be in the sandbox now
 _lua_reset_env()
@@ -392,4 +396,4 @@ _lua_reset_env()
 _lua_reset_env()
 -- Now we should be in the sandbox environment
 
-return _lua_set_python_loader
+return { _lua_set_python_loader, _clear_loadData_cache }

--- a/wikitextprocessor/luaexec.py
+++ b/wikitextprocessor/luaexec.py
@@ -294,7 +294,9 @@ def initialize_lua(ctx):
     # bigger phase 2 of the sandbox.  This way, most of the sandbox loading
     # will benefit from caching and precompilation (when implemented).
     with open(lua_dir + "_sandbox_phase1.lua", encoding="utf-8") as f:
-        set_loader = lua.execute(f.read())
+        phase1_result = lua.execute(f.read())
+        set_loader = phase1_result[1]
+        clear_loaddata_cache = phase1_result[2]
         # Call the function that sets the Lua loader
         set_loader(lambda x: lua_loader(ctx, x))
 
@@ -305,6 +307,7 @@ def initialize_lua(ctx):
     set_functions = ret[1]
     ctx.lua_invoke = ret[2]
     ctx.lua_reset_env = ret[3]
+    ctx.lua_clear_loaddata_cache = clear_loaddata_cache
 
     # Set Python functions for Lua
     call_set_functions(ctx, set_functions)


### PR DESCRIPTION
According to Scribunto
document(https://www.mediawiki.org/wiki/Extension:Scribunto/Lua_reference_manual#mw.loadData), `mw.loadData()` evalutates the loaded module only once per page, rather than once per `{{#invoke:}}` call. The cache should be cleared for each page, otherwise some module like
`Module:headword/data`(https://en.wiktionary.org/wiki/Module:headword/data) would use old cached page title.