### PR TITLE
Add test GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: test
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - '*'
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11']
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+      - run: |
+          python -m pip install -U pip
+          python -m pip install --use-pep517 '.[dev]'
+      - run: make test


### PR DESCRIPTION
This would run tests when commits are pushed to a branch or pull request. And it won't interfere with existing test workflow. The test results can be viewed from my forked repository: https://github.com/xxyzz/wikitextprocessor/actions/runs/5195143853