### PR TITLE
Upload code coverage HTML files to GitHub Pages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,3 +31,21 @@ jobs:
           python -m pip install -U pip
           python -m pip install --use-pep517 '.[dev]'
       - run: make test
+      - uses: actions/upload-pages-artifact@v1
+        if: github.ref_name == 'main' && matrix.python-version == '3.11'
+        with:
+          path: htmlcov
+
+  depoly:
+    if: github.ref_name == 'main'
+    needs: test
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v2

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,8 @@
 # Run "make clean" to remove automatically generated files
 
 test:
-	rm -rf .coverage*
-	python -m nose2 --output-buffer --with-coverage --coverage-report=html --coverage-config=tests/testcov.conf --pretty-assert
-	rm -rf htmlcov
-	mv -f htmlcov.new htmlcov
-
+	rm -rf .coverage htmlcov
+	python -m nose2 --output-buffer --pretty-assert --with-coverage --coverage-report=html
 clean:
 	rm -rf __pycache__
-	rm -rf .coverage* htmlcov*
+	rm -rf .coverage htmlcov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["nose2[coverage_plugin]"]
+dev = [
+    "nose2[coverage_plugin]",
+    "tomli; python_version <= '3.10'",  # for coverage parsing TOML file
+]
 
 [project.urls]
 homepage = "https://github.com/tatuylonen/wikitextprocessor"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,3 +67,8 @@ wikitextprocessor = [
 
 [tool.mypy]
 mypy_path = "typestubs"
+
+[tool.coverage.run]
+branch = true
+concurrency = ["multiprocessing"]
+omit = ["tests/*", "get_namespaces.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,4 +74,4 @@ mypy_path = "typestubs"
 [tool.coverage.run]
 branch = true
 concurrency = ["multiprocessing"]
-omit = ["tests/*", "get_namespaces.py"]
+omit = ["tests/*"]

--- a/tests/testcov.conf
+++ b/tests/testcov.conf
@@ -1,7 +1,0 @@
-[run]
-omit = tests/*, koe*, temp*, extract_language_codes.py, setup.py
-branch = True
-concurrency = multiprocessing
-
-[html]
-directory = htmlcov.new

--- a/tools/get_namespaces.py
+++ b/tools/get_namespaces.py
@@ -1,6 +1,5 @@
 import argparse
 import json
-import sys
 from pathlib import Path
 
 import requests
@@ -67,9 +66,11 @@ def main():
     data_folder = Path(f"wikitextprocessor/data/{args.lang_code}")
     if not data_folder.exists():
         data_folder.mkdir()
-    with data_folder.joinpath("namespaces.json").open("w", encoding="utf-8") as f:
+    with data_folder.joinpath("namespaces.json").open(
+        "w", encoding="utf-8"
+    ) as f:
         json.dump(json_dict, f, ensure_ascii=False, indent=2)
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()


### PR DESCRIPTION
GitHub Pages need to be enabled at page https://github.com/tatuylonen/wikitextprocessor/settings/pages, the build source needs to be set to "GitHub Actions".

A preview of the coverage pages: https://xxyzz.github.io/wikitextprocessor