### PR TITLE
Don't clean `-{}-` template arguemnt, again...

### DIFF
--- a/tests/test_wikiprocess.py
+++ b/tests/test_wikiprocess.py
@@ -2,12 +2,10 @@
 #
 # Copyright (c) 2020, 2021, 2022 Tatu Ylonen.  See file LICENSE and https://ylonen.org
 
-import os
 import math
 import time
 import unittest
 
-from pathlib import Path
 from typing import List, Tuple
 
 from wikitextprocessor import Wtp
@@ -3262,6 +3260,9 @@ return export
         self.scribunto("fOOf[[]]",
                        """a = {}; a["o"] = "O";
 	               return mw.ustring.gsub("foof[[]]", ".", a);""")
+
+
+
 
 # XXX Test template_fn
 

--- a/wikitextprocessor/core.py
+++ b/wikitextprocessor/core.py
@@ -1528,7 +1528,8 @@ class Wtp:
 
         # Remove LanguageConverter markups:
         # https://www.mediawiki.org/wiki/Writing_systems/Syntax
-        if not pre_expand and self.lang_code == "zh":
+        # but ignore `-{}-` template argument placeholder: #59
+        if not pre_expand and self.lang_code == "zh" and text != "-{}-":
             expanded = expanded.replace("-{", "").replace("}-", "")
 
         return expanded


### PR DESCRIPTION
b41d4145e7c30a3397f747d73ae390c9f831f094 doesn't preserve `-{}-` template argument placeholder.

Fix bug in b41d4145e7c30a3397f747d73ae390c9f831f094 and add a test.