### PR TITLE
Fix `mw.title.getCurrentTitle` returns `nil` Lua error for page "1:e"

### DIFF
--- a/tests/test_wikiprocess.py
+++ b/tests/test_wikiprocess.py
@@ -48,6 +48,7 @@ return export
 """]])
         ctx.start_page("Tt")
         ret = ctx.expand("{{#invoke:testmod|testfn}}", timeout=timeout)
+        ctx.close_db_conn()
         self.assertEqual(len(ctx.expand_stack), 1)
         self.assertEqual(ret, expected_ret)
 
@@ -3262,6 +3263,8 @@ return export
 	               return mw.ustring.gsub("foof[[]]", ".", a);""")
 
 
+    def test_title_1_colon_e(self) -> None:
+        self.scribunto("1:e", "return mw.title.new('1:e').text")
 
 
 # XXX Test template_fn

--- a/wikitextprocessor/core.py
+++ b/wikitextprocessor/core.py
@@ -1829,7 +1829,7 @@ class Wtp:
         else:
             placeholders = []
         query_str += " ORDER BY title ASC"
-        print(f"Getting all pages for query: '{query_str}'")
+        # print(f"Getting all pages for query: '{query_str}'")
 
         for result in self.db_conn.execute(
             query_str, placeholders,

--- a/wikitextprocessor/lua/mw_title.lua
+++ b/wikitextprocessor/lua/mw_title.lua
@@ -159,10 +159,10 @@ function mw_title.makeTitle(namespace, title, fragment, interwiki)
      NAMESPACE_DATA.File.name .. ":",
      NAMESPACE_DATA.Special.name .. ":",
    }
-   for v in ipairs(NAMESPACE_DATA.Project.aliases) do
+   for i, v in ipairs(NAMESPACE_DATA.Project.aliases) do
     table.insert(prefixes, v .. ":")
    end
-   for v in ipairs(NAMESPACE_DATA.File.aliases) do
+   for i, v in ipairs(NAMESPACE_DATA.File.aliases) do
     table.insert(prefixes, v .. ":")
    end
    -- XXX other disallowed prefixes, see


### PR DESCRIPTION
previous Lua code only adds the array index number but not the value to the `prefixes` table.

Checking page namespace at here probably is not needed, since only main and reconstruction namespaces are queried in the second phase.