### PR TITLE
Fix template name variable got overwritten by called template name bug

### DIFF
--- a/tests/test_wikiprocess.py
+++ b/tests/test_wikiprocess.py
@@ -3276,7 +3276,7 @@ return export
         '''
         wtp = Wtp(lang_code="zh")
         # source page need_pre_expand is true
-        wtp.add_page("Template:意大利語", 10, body="==意大利语==")
+        wtp.add_page("Template:意大利語", 10, body="{{NoEdit|==意大利语==}}")
         wtp.add_page("Template:-it-", 10, redirect_to="Template:意大利語")
         wtp.analyze_templates()
         source_page = wtp.get_page("Template:-it-", 10)
@@ -3286,7 +3286,7 @@ return export
 
         # destination page need_pre_expand is true
         wtp.add_page("Template:意大利語", 10, redirect_to="Template:-it-")
-        wtp.add_page("Template:-it-", 10, body="==意大利语==")
+        wtp.add_page("Template:-it-", 10, body="{{NoEdit|==意大利语==}}")
         wtp.analyze_templates()
         dest_page = wtp.get_page("Template:-it-", 10)
         self.assertTrue(dest_page.need_pre_expand)

--- a/wikitextprocessor/core.py
+++ b/wikitextprocessor/core.py
@@ -918,11 +918,12 @@ class Wtp:
         for m in re.finditer(
             r"(?s)(^|[^{])(\{\{)?\{\{([^{]*?)(\||\}\})", unpaired_text
         ):
-            name = m.group(3)
-            name = re.sub(r"(?si)<\s*nowiki\s*/\s*>", "", name)
-            if not name:
-                continue
-            included_templates.add(name)
+            called_template = m.group(3)
+            called_template = re.sub(
+                r"(?si)<\s*nowiki\s*/\s*>", "", called_template
+            )
+            if len(called_template) > 0:
+                included_templates.add(called_template)
 
         # Chinese Wiktionary language and POS subtitle template
         # uses "langhd" template


### PR DESCRIPTION
`Wtp._analyze_template()`'s local variable for called template name overwrites the analyzed template name, which would cause the following check Chinese Wiktionary heading template code uses the called template name.