### PR TITLE
Add unittest.TestCase.tearDown() to delete temporary db files

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -48,7 +48,7 @@ class ParserTests(unittest.TestCase):
 
     def test_hdr2a(self):
         tree = self.parse("test", "==Foo==")
-        assert len(tree.children) == 1
+        self.assertEqual(len(tree.children), 1)
         child = tree.children[0]
         self.assertEqual(child.kind, NodeKind.LEVEL2)
         self.assertEqual(child.args, [["Foo"]])
@@ -56,7 +56,7 @@ class ParserTests(unittest.TestCase):
 
     def test_hdr2b(self):
         tree = self.parse("test", "== Foo:Bar ==\nZappa\n")
-        assert len(tree.children) == 1
+        self.assertEqual(len(tree.children), 1)
         child = tree.children[0]
         self.assertEqual(child.kind, NodeKind.LEVEL2)
         self.assertEqual(child.args, [["Foo:Bar"]])
@@ -64,7 +64,7 @@ class ParserTests(unittest.TestCase):
 
     def test_hdr2c(self):
         tree = self.parse("test", "=== Foo:Bar ===\nZappa\n")
-        assert len(tree.children) == 1
+        self.assertEqual(len(tree.children), 1)
         child = tree.children[0]
         self.assertEqual(child.kind, NodeKind.LEVEL3)
         self.assertEqual(child.args, [["Foo:Bar"]])
@@ -72,7 +72,7 @@ class ParserTests(unittest.TestCase):
 
     def test_hdr23a(self):
         tree = self.parse("test", "==Foo==\na\n===Bar===\nb\n===Zappa===\nc\n")
-        assert len(tree.children) == 1
+        self.assertEqual(len(tree.children), 1)
         h2 = tree.children[0]
         self.assertEqual(h2.kind, NodeKind.LEVEL2)
         self.assertEqual(len(h2.children), 3)
@@ -88,7 +88,7 @@ class ParserTests(unittest.TestCase):
 
     def test_hdr23b(self):
         tree = self.parse("test", "==Foo==\na\n===Bar===\nb\n==Zappa==\nc\n")
-        assert len(tree.children) == 2
+        self.assertEqual(len(tree.children), 2)
         h2a = tree.children[0]
         h2b = tree.children[1]
         self.assertEqual(h2a.kind, NodeKind.LEVEL2)
@@ -140,7 +140,7 @@ dasfasddasfdas
 
     def test_nowiki1(self):
         tree = self.parse("test", "==Foo==\na<nowiki>\n===Bar===\nb</nowiki>\n==Zappa==\nc\n")
-        assert len(tree.children) == 2
+        self.assertEqual(len(tree.children), 2)
         h2a = tree.children[0]
         h2b = tree.children[1]
         self.assertEqual(h2a.kind, NodeKind.LEVEL2)
@@ -153,7 +153,7 @@ dasfasddasfdas
 
     def test_nowiki2(self):
         tree = self.parse("test", "<<nowiki/>foo>")
-        assert tree.children == ["<<nowiki />foo>"]
+        self.assertEqual(tree.children, ["<<nowiki />foo>"])
 
     def test_nowiki3(self):
         tree = self.parse("test", "&<nowiki/>amp;")
@@ -365,7 +365,7 @@ dasfasddasfdas
         tree = self.parse("test", "<b <!-- bar -->>foo</b>")
         self.assertEqual(len(tree.children), 1)
         a = tree.children[0]
-        assert isinstance(a, WikiNode)
+        self.assertTrue(isinstance(a, WikiNode))
         self.assertEqual(a.kind, NodeKind.HTML)
         self.assertEqual(a.args, "b")
         self.assertEqual(a.children, ["foo"])
@@ -376,7 +376,7 @@ dasfasddasfdas
         self.assertEqual(self.ctx.errors, [])
         self.assertEqual(len(tree.children), 1)
         a = tree.children[0]
-        assert isinstance(a, WikiNode)
+        self.assertTrue(isinstance(a, WikiNode))
         self.assertEqual(a.kind, NodeKind.HTML)
         self.assertEqual(a.args, "br")
         self.assertEqual(a.children, [])
@@ -386,7 +386,7 @@ dasfasddasfdas
         self.assertEqual(self.ctx.errors, [])
         self.assertEqual(len(tree.children), 1)
         a = tree.children[0]
-        assert isinstance(a, WikiNode)
+        self.assertTrue(isinstance(a, WikiNode))
         self.assertEqual(a.kind, NodeKind.HTML)
         self.assertEqual(a.args, "wbr")
         self.assertEqual(a.children, [])
@@ -396,7 +396,7 @@ dasfasddasfdas
         self.assertEqual(self.ctx.errors, [])
         self.assertEqual(len(tree.children), 1)
         a = tree.children[0]
-        assert isinstance(a, WikiNode)
+        self.assertTrue(isinstance(a, WikiNode))
         self.assertEqual(a.kind, NodeKind.HTML)
         self.assertEqual(a.args, "tt")
         self.assertEqual(a.children,
@@ -407,7 +407,7 @@ dasfasddasfdas
         self.assertEqual(self.ctx.errors, [])
         self.assertEqual(len(tree.children), 1)
         a = tree.children[0]
-        assert isinstance(a, WikiNode)
+        self.assertTrue(isinstance(a, WikiNode))
         self.assertEqual(a.kind, NodeKind.HTML)
         self.assertEqual(a.args, "span")
         self.assertEqual(a.children, ["["])
@@ -427,7 +427,7 @@ dasfasddasfdas
         self.assertEqual(self.ctx.debugs, [])
         self.assertEqual(len(tree.children), 1)
         a = tree.children[0]
-        assert isinstance(a, WikiNode)
+        self.assertTrue(isinstance(a, WikiNode))
         self.assertEqual(a.kind, NodeKind.HTML)
         self.assertEqual(a.args, "div")
         self.assertEqual(a.children, ["foo"])
@@ -441,7 +441,7 @@ dasfasddasfdas
         self.assertEqual(self.ctx.debugs, [])
         self.assertEqual(len(tree.children), 1)
         a = tree.children[0]
-        assert isinstance(a, WikiNode)
+        self.assertTrue(isinstance(a, WikiNode))
         self.assertEqual(a.kind, NodeKind.HTML)
 
     def test_html17(self):
@@ -456,7 +456,7 @@ dasfasddasfdas
         self.assertEqual(self.ctx.debugs, [])
         self.assertEqual(len(tree.children), 1)
         a = tree.children[0]
-        assert isinstance(a, WikiNode)
+        self.assertTrue(isinstance(a, WikiNode))
         self.assertEqual(a.kind, NodeKind.HTML)
 
     def test_html18(self):
@@ -469,7 +469,7 @@ dasfasddasfdas
         self.assertEqual(self.ctx.debugs, [])
         self.assertEqual(len(tree.children), 1)
         a = tree.children[0]
-        assert isinstance(a, WikiNode)
+        self.assertTrue(isinstance(a, WikiNode))
         self.assertEqual(a.kind, NodeKind.HTML)
         self.assertEqual(a.args, "div")
         self.assertEqual(a.children, ["foo"])
@@ -2003,7 +2003,7 @@ def foo(x):
 | $1.90
 |}""")
         x = str(tree)  # This print is part of the text, do not remove
-        assert isinstance(x, str)
+        self.assertTrue(isinstance(x, str))
 
     def test_repr(self):
         tree = self.parse("test", """{| class="wikitable"
@@ -2024,7 +2024,7 @@ def foo(x):
 | $1.90
 |}""")
         x = repr(tree)
-        assert isinstance(x, str)
+        self.assertTrue(isinstance(x, str))
 
     def test_file_animal(self):
         with open("tests/animal.txt", "r") as f:
@@ -2044,16 +2044,18 @@ def foo(x):
     def test_newline_template_argument_in_list(self):
         # new line characters in template arguments shouldn't pop the parser
         # stack to break the template node.
-        origin_wikitext = """#*{{  foo
+        wikitext = """#*{{  foo
 |bar
 |baz
 }}"""
-        tree = self.parse("test_page", origin_wikitext)
-        a = tree.children[0]
-        b = a.children[0]
-        t = b.children[0]
-        assert(t.children == [])
-        assert(t.args == [['  foo\n'], ['bar\n'], ['baz\n']])
+        tree = self.parse("test_page", wikitext)
+        list_node = tree.children[0]
+        list_item_node = list_node.children[0]
+        template_node = list_item_node.children[0]
+        self.assertEqual(template_node.children, [])
+        self.assertEqual(
+            template_node.args, [['  foo\n'], ['bar\n'], ['baz\n']]
+        )
 
     def test_empty_language_converter_template_argument(self):
         """

--- a/tests/test_wikiprocess.py
+++ b/tests/test_wikiprocess.py
@@ -1570,7 +1570,10 @@ MORE
         # Test infinite recursion in template expansion
         self.ctx.start_page("Tt")
         ret = self.ctx.expand('{{foo}}')
-        assert ret.find('<strong class="error">too deep recursion') >= 0
+        self.assertGreaterEqual(
+            ret.find('<strong class="error">too deep recursion'),
+            0
+        )
 
     @patch(
         "wikitextprocessor.core.Wtp.get_page",
@@ -3470,7 +3473,7 @@ return export
         # For security, Python should not be callable from Lua modules
         self.ctx.start_page("Tt")
         ret = self.ctx.expand("{{#invoke:testmod|testfn}}")
-        assert ret.startswith('<strong class="error">')
+        self.assertTrue(ret.startswith('<strong class="error">'))
 
     def test_sandbox2(self):
         # For security, dangerous Lua functions should not be callable from

--- a/wikitextprocessor/core.py
+++ b/wikitextprocessor/core.py
@@ -43,7 +43,7 @@ from pathlib import Path
 from .parserfns import PARSER_FUNCTIONS, call_parser_function, init_namespaces
 from .wikihtml import ALLOWED_HTML_TAGS
 from .luaexec import call_lua_sandbox
-from .parser import parse_encoded, NodeKind
+from .parser import parse_encoded, NodeKind, WikiNode
 from .common import (
     MAGIC_FIRST,
     MAGIC_LAST,
@@ -55,7 +55,6 @@ from .dumpparser import process_dump
 from .node_expand import to_wikitext, to_html, to_text
 
 if TYPE_CHECKING:
-    from .parser import WikiNode
     from .parserfns import Namespace
     from lupa.lua51 import LuaRuntime, _LuaTable, LuaNumber
 
@@ -141,10 +140,10 @@ _global_page_handler: Callable[["Page"], PageHandlerReturn]
 class Page:
     title: str
     namespace_id: int
-    redirect_to: Optional[str]
-    need_pre_expand: bool
-    body: Optional[str]
-    model: Optional[str]
+    redirect_to: Optional[str] = None
+    need_pre_expand: bool = False
+    body: Optional[str] = None
+    model: Optional[str] = None
 
 
 def phase2_page_handler(
@@ -380,7 +379,7 @@ class Wtp:
         include_redirects: bool = True,
         search_pattern: Optional[str] = None,
     ) -> Tuple[str, List[Union[str, int]]]:
-        
+
         and_strs = []
         where_str = ""
         if namespace_ids is not None:
@@ -956,7 +955,7 @@ class Wtp:
                                         |    \}[^}]
                                         )*?
                                     \}\}""",
-                
+
                           "", newt)
             # print("After templ elim: {!r}".format(newt))
             if newt == outside:
@@ -1750,7 +1749,7 @@ class Wtp:
         self,
         path: str,
         page_handler: Callable[["Page"],
-                                # -> 
+                                # ->
                                 PageHandlerReturn],
         namespace_ids: Set[int],
         phase1_only=False,
@@ -1847,7 +1846,7 @@ class Wtp:
                     )
                 )
                 last_t = time.time()
-            
+
 
         ret: Optional[PageHandlerReturn]
         if self.num_threads == 1:
@@ -2033,14 +2032,14 @@ class Wtp:
 
     def parse(
         self,
-        text,
+        text: str,
         pre_expand=False,
         expand_all=False,
         additional_expand=None,
         do_not_pre_expand=None,
         template_fn=None,
         post_template_fn=None,
-    ):
+    ) -> WikiNode:
         """Parses the given text into a parse tree (WikiNode tree).  If
         ``pre_expand`` is True, then before parsing this will expand
         those templates that have been detected to potentially

--- a/wikitextprocessor/parser.py
+++ b/wikitextprocessor/parser.py
@@ -1,15 +1,17 @@
 # Simple WikiMedia markup (WikiText) syntax parser
 #
 # Copyright (c) 2020-2022 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
-import re
 import enum
 import html
+import re
+
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Tuple
+
 from .parserfns import PARSER_FUNCTIONS
 from .wikihtml import ALLOWED_HTML_TAGS
 from .common import (MAGIC_NOWIKI_CHAR, MAGIC_FIRST, MAGIC_LAST, nowiki_quote,
                      MAGIC_SQUOTE_CHAR)
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .core import Wtp
@@ -1564,7 +1566,7 @@ def bold_follows(parts, i):
     return False
 
 
-def token_iter(ctx, text):
+def token_iter(ctx: "Wtp", text: str) -> Iterator[Tuple[bool, str]]:
     """Tokenizes MediaWiki page content.  This yields (is_token, text) for
     each token.  ``is_token`` is False for text and True for other tokens.
     Wikitext bold and italic are interpreted WITHIN A SINGLE LINE.  It seems
@@ -1692,7 +1694,7 @@ def token_iter(ctx, text):
                 yield False, part[pos:]
 
 
-def process_text(ctx, text):
+def process_text(ctx: "Wtp", text: str) -> None:
     """Tokenizes ``text`` and processes each token in sequence.  This can be
     called recursively (which we do to process tokens inside templates and
     certain other structures)."""
@@ -1744,7 +1746,7 @@ def process_text(ctx, text):
         ctx.beginning_of_line = token[-1] == "\n"
 
 
-def parse_encoded(ctx, text):
+def parse_encoded(ctx: "Wtp", text: str) -> WikiNode:
     """Parses the text, which should already have been encoded using magic
     characters (see Wtp._encode()).  Parses the encoded string and returns
     the parse tree."""


### PR DESCRIPTION
`test_invoke8` and `test_invoke13` are removed because they are duplicate of `test_invoke7` and `test_invoke12`.

The temporary SQLite files will be deleted even when the tests fail.