### PR TITLE
Assign `string.uupper` and `string.ulower` Lua function to fix Lua error in Module:languages

### DIFF
--- a/wikitextprocessor/lua/_sandbox_phase2.lua
+++ b/wikitextprocessor/lua/_sandbox_phase2.lua
@@ -231,6 +231,11 @@ local function _lua_set_functions(
    mw_python_fetch_language_names = fetch_language_names
    mw_wikibase_getlabel_python = mw_wikibase_getlabel
    mw_wikibase_getdesc_python = mw_wikibase_getdesc
+
+   -- This is set in https://github.com/wikimedia/mediawiki-extensions-Scribunto/blob/4aa17cb80c72998b9cead27e5be1ca39d8a0cfed/includes/Engines/LuaCommon/lualib/mw.language.lua#L27-L28
+   -- and used in https://en.wiktionary.org/wiki/Module:languages
+   string.uupper = mw.ustring.upper
+   string.ulower = mw.ustring.lower
 end
 
 


### PR DESCRIPTION
These two functions are created in `language.setupInterface`(https://github.com/wikimedia/mediawiki-extensions-Scribunto/blob/4aa17cb80c72998b9cead27e5be1ca39d8a0cfed/includes/Engines/LuaCommon/lualib/mw.language.lua#L27-L28) and the recent change to page `Module:languages` used them to replace `mw.ustring.upper` and `mw.ustring.lower`(https://en.wiktionary.org/w/index.php?title=Module:languages&diff=prev&oldid=75145580).