### PR TITLE
Fix `index nil` Lua error in English Wiktionary "Module:Message box"

### DIFF
--- a/wikitextprocessor/lua/mw_html.lua
+++ b/wikitextprocessor/lua/mw_html.lua
@@ -177,16 +177,16 @@ function Html:css(name, value)
 end
 
 function Html:cssText(new_css)
-   if new_css == nil or new_css == "" then return end
-   if mw.ustring.sub(new_css, -1) ~= ";" then new_css = new_css .. ";" end
-      local css = self:getAttr("style") or ""
-   if css == "" then
-      css = new_css
-   else
-      css = css .. new_css
-   end
-   self:attr("style", css)
-   return self
+    if new_css == nil or new_css == "" then return self end
+    if mw.ustring.sub(new_css, -1) ~= ";" then new_css = new_css .. ";" end
+    local css = self:getAttr("style") or ""
+    if css == "" then
+        css = new_css
+    else
+        css = css .. new_css
+    end
+    self:attr("style", css)
+    return self
 end
 
 function Html:done()


### PR DESCRIPTION
https://www.mediawiki.org/wiki/Extension:Scribunto/Lua_reference_manual#mw.html:cssText Scribunto document and code
https://github.com/wikimedia/mediawiki-extensions-Scribunto/blob/c588e717ab150ecfe951e4356d7c6331bf264f18/includes/Engines/LuaCommon/lualib/mw.html.lua#L376-L384 say the "mw.html:cssText" function: "If a nil parameter is passed, this is a no-op.", so it should not return `nil`.

