### PR TITLE
Add mw.message Lua library

### DIFF
--- a/wikitextprocessor/lua/mw.lua
+++ b/wikitextprocessor/lua/mw.lua
@@ -13,6 +13,7 @@ local mw_autoload = {
    uri = "mw_uri",
    ustring = "ustring:ustring",
    wikibase = "mw_wikibase",
+   message = "mw_message",
    getContentLanguage = function(table)
       return table.language.getContentLanguage
    end,

--- a/wikitextprocessor/lua/mw_language.lua
+++ b/wikitextprocessor/lua/mw_language.lua
@@ -154,14 +154,16 @@ function Language:formatNum(n, options)
 end
 
 function Language:formatDate(format, timestamp, localtime)
-   -- XXX currently ignores localtime
-   if not timestamp then
-      timestamp = os.date("%Y-%m-%d %X")
-   end
-   -- XXX actually format the time.  See
-   -- https://www.mediawiki.org/wiki/Help:Extension:ParserFunctions#.23time
-   -- form supported timestamp formats and format specification.
-   return timestamp
+    -- XXX currently ignores localtime
+    if format == "U" then
+        timestamp = os.time()
+    elseif not timestamp then
+        timestamp = os.date("%Y-%m-%d %X")
+    end
+    -- XXX actually format the time.  See
+    -- https://www.mediawiki.org/wiki/Help:Extension:ParserFunctions#.23time
+    -- form supported timestamp formats and format specification.
+    return timestamp
 end
 
 function Language:formatDuration(seconds, allowedIntervals)

--- a/wikitextprocessor/lua/mw_message.lua
+++ b/wikitextprocessor/lua/mw_message.lua
@@ -1,0 +1,186 @@
+-- https://www.mediawiki.org/wiki/Help:System_message
+-- remove php code from Scribunto
+-- https://github.com/wikimedia/mediawiki-extensions-Scribunto/blob/master/includes/Engines/LuaCommon/lualib/mw.message.lua
+
+local message = {}
+
+local util = require 'libraryUtil'
+local checkType = util.checkType
+
+local valuemt = {
+    __tostring = function(t)
+        return tostring(t.raw or t.num)
+    end
+}
+
+local function checkScalar(name, argIdx, arg, level, valuemtOk)
+    local tp = type(arg)
+
+    -- If special params are ok, detect them
+    if valuemtOk and tp == 'table' and getmetatable(arg) == valuemt then
+        return arg
+    end
+
+    -- If it's a table with a custom __tostring function, use that string
+    if tp == 'table' and getmetatable(arg) and getmetatable(arg).__tostring then
+        return tostring(arg)
+    end
+
+    if tp ~= 'string' and tp ~= 'number' then
+        error(string.format(
+            "bad argument #%d to '%s' (string or number expected, got %s)",
+            argIdx, name, tp
+        ), level + 1)
+    end
+
+    return arg
+end
+
+local function checkParams(name, valueOk, ...)
+    -- Accept an array of params, or params as individual command line arguments
+    local params, nparams
+    local first = select(1, ...)
+    if type(first) == 'table' and
+        not (getmetatable(first) and getmetatable(first).__tostring)
+    then
+        if select('#', ...) == 1 then
+            params = first
+            nparams = table.maxn(params)
+        else
+            error(
+                "bad arguments to '" ..
+                name ..
+                "' (pass either a table of params or params as individual arguments)",
+                3
+            )
+        end
+    else
+        params = { ... }
+        nparams = select('#', ...)
+    end
+    for i = 1, nparams do
+        params[i] = checkScalar('params', i, params[i], 3, valueOk)
+    end
+    return params
+end
+
+local function makeMessage(options)
+    local obj = {}
+    local checkSelf = util.makeCheckSelfFunction('mw.message', 'msg', obj,
+        'message object')
+
+    local data = {
+        keys = options.keys,
+        rawMessage = options.rawMessage,
+        params = {},
+        lang = mw.language.new("en"),
+        useDB = true,
+    }
+
+    function obj:params(...)
+        checkSelf(self, 'params')
+        local params = checkParams('params', true, ...)
+        local j = #data.params
+        for i = 1, #params do
+            data.params[j + i] = params[i]
+        end
+        return self
+    end
+
+    function obj:rawParams(...)
+        checkSelf(self, 'rawParams')
+        local params = checkParams('rawParams', false, ...)
+        local j = #data.params
+        for i = 1, #params do
+            data.params[j + i] = setmetatable({ raw = params[i] }, valuemt)
+        end
+        return self
+    end
+
+    function obj:numParams(...)
+        checkSelf(self, 'numParams')
+        local params = checkParams('numParams', false, ...)
+        local j = #data.params
+        for i = 1, #params do
+            data.params[j + i] = setmetatable({ num = params[i] }, valuemt)
+        end
+        return self
+    end
+
+    function obj:inLanguage(lang)
+        checkSelf(self, 'inLanguage')
+        if type(lang) == 'table' and lang.getCode then
+            -- probably a mw.language object
+            lang = lang:getCode()
+        end
+        checkType('inLanguage', 1, lang, 'string')
+        data.lang = lang
+        return self
+    end
+
+    function obj:useDatabase(value)
+        checkSelf(self, 'useDatabase')
+        checkType('useDatabase', 1, value, 'boolean')
+        data.useDB = value
+        return self
+    end
+
+    function obj:plain()
+        checkSelf(self, 'plain')
+        return data.keys
+    end
+
+    function obj:exists()
+        checkSelf(self, 'exists')
+        return true
+    end
+
+    function obj:isBlank()
+        checkSelf(self, 'isBlank')
+        return false
+    end
+
+    function obj:isDisabled()
+        checkSelf(self, 'isDisabled')
+        return false
+    end
+
+    return setmetatable(obj, {
+        __tostring = function(t)
+            return t:plain()
+        end
+    })
+end
+
+function message.new(key, ...)
+    checkType('message.new', 1, key, 'string')
+    return makeMessage { keys = { key } }:params(...)
+end
+
+function message.newFallbackSequence(...)
+    for i = 1, math.max(1, select('#', ...)) do
+        checkType('message.newFallbackSequence', i, select(i, ...), 'string')
+    end
+    return makeMessage { keys = { ... } }
+end
+
+function message.newRawMessage(msg, ...)
+    checkType('message.newRawMessage', 1, msg, 'string')
+    return makeMessage { rawMessage = msg }:params(...)
+end
+
+function message.rawParam(value)
+    value = checkScalar('message.rawParam', 1, value)
+    return setmetatable({ raw = value }, valuemt)
+end
+
+function message.numParam(value)
+    value = checkScalar('message.numParam', 1, value)
+    return setmetatable({ num = value }, valuemt)
+end
+
+function message.getDefaultLanguage()
+    return mw.language.new("en")
+end
+
+return message

--- a/wikitextprocessor/parserfns.py
+++ b/wikitextprocessor/parserfns.py
@@ -46,7 +46,7 @@ def if_fn(ctx: "Wtp", fn_name: str,
           expander: Callable[[str], str]
          ) -> str:
     """Implements #if parser function."""
-    # print(f"if_fn: {args}") 
+    # print(f"if_fn: {args}")
     arg0: str = args[0] if args else ""
     arg1: str = args[1] if len(args) >= 2 else ""
     arg2: str = args[2] if len(args) >= 3 else ""
@@ -1349,7 +1349,7 @@ def time_fn(
         # people on wiktionary don't go crazy with weird formatting
         t = dateparser.parse(dt, settings=settings)
         if t is None:
-            m = re.match(r"([^+]*)\s*(\+\s*\d+\s*(day|year|month)s?)\s*$", 
+            m = re.match(r"([^+]*)\s*(\+\s*\d+\s*(day|year|month)s?)\s*$",
                          orig_dt)
             if m:
                 main_date = dateparser.parse(m.group(1), settings=settings)
@@ -1560,6 +1560,16 @@ def urldecode_fn(
     return ret
 
 
+def shortdesc_fn(
+    ctx: "Wtp",
+    fn_name: str,
+    args: List[str],
+    expander: Callable[[str], str]
+) -> str:
+    # https://en.wikipedia.org/wiki/Wikipedia:Short_description
+    return ""
+
+
 def unimplemented_fn(
     ctx: "Wtp",
     fn_name: str,
@@ -1602,7 +1612,7 @@ PARSER_FUNCTIONS = {
     "ARTICLESPACEE": unimplemented_fn,
     "SUBJECTSPACEE": unimplemented_fn,
     "TALKSPACEE": unimplemented_fn,
-    "SHORTDESC": unimplemented_fn,
+    "SHORTDESC": shortdesc_fn,
     "SITENAME": unimplemented_fn,
     "SERVER": server_fn,
     "SERVERNAME": servername_fn,


### PR DESCRIPTION
All three commits are simple implementations to fix errors in the English Wikipedia page "Free neutron decay".

The [message](https://www.mediawiki.org/wiki/Help:System_message) library is for getting localized strings. I just return the massage key, we could implement it in the future if it's needed for expanding templates. And the message data are stored in JSON files: https://github.com/wikimedia/mediawiki/tree/master/languages/i18n