### PR TITLE
Change template parameter name to int value if it's a number

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2399,6 +2399,15 @@ def foo(x):
             self.assertTrue(isinstance(template_node, TemplateNode))
             self.assertTrue(template_node.template_name, "foo")
 
+    def test_template_parameter_contains_equals_sign(self):
+        # https://fr.wiktionary.org/wiki/L2#Dérivés
+        tree = self.parse("", "{{lien|1=L1 = L2 hypothesis|lang=en}}")
+        node = tree.children[0]
+        self.assertTrue(isinstance(node, TemplateNode))
+        self.assertTrue(
+            node.template_parameters, {1: "L1 = L2 hypothesis", "lang": "en"}
+        )
+
 
 # XXX implement <nowiki/> marking for links, templates
 #  - https://en.wikipedia.org/wiki/Help:Wikitext#Nowiki

--- a/tests/test_wikiprocess.py
+++ b/tests/test_wikiprocess.py
@@ -4172,6 +4172,9 @@ return export
         page = self.ctx.get_page("q", 10)
         self.assertEqual(page.title, "Template:q")
 
+    def test_get_page_empty_title(self):
+        self.assertEqual(self.ctx.get_page(""), None)
+
 # XXX Test template_fn
 
 # XXX test post_template_fn

--- a/wikitextprocessor/core.py
+++ b/wikitextprocessor/core.py
@@ -1689,6 +1689,8 @@ class Wtp:
         title = title.replace("_", " ")
         if title.startswith("Main:"):
             title = title[5:]
+        if len(title) == 0:
+            return None
 
         upper_case_title = title  # the first letter is upper case
         if namespace_id is not None and namespace_id != 0:

--- a/wikitextprocessor/parser.py
+++ b/wikitextprocessor/parser.py
@@ -503,6 +503,9 @@ class TemplateNode(WikiNode):
                             parameter_value = parameter[
                                 equal_sign_index + 1 :
                             ].strip()
+                            if parameter_name.isdigit():  # value contains "="
+                                parameter_name = int(parameter_name)
+                                is_named = False
                             if len(parameter_value) > 0:
                                 parameters[parameter_name].append(
                                     parameter_value


### PR DESCRIPTION
Unnamed template parameter might also use named parameters format if the value contains "=".