### PR TITLE
Pass namespace canonical name to Lua class `Namespace`

### DIFF
--- a/wikitextprocessor/lua/mw_site.lua
+++ b/wikitextprocessor/lua/mw_site.lua
@@ -21,7 +21,7 @@ Namespace.__index = Namespace
 function Namespace:new(obj)
    obj = obj or {}
    setmetatable(obj, self)
-   obj.canonicalName = obj.name
+   obj.canonicalName = obj.canonical
    obj.displayName = obj.name
    obj.hasSubpages = obj.name == "Main" or obj.name == NAMESPACE_DATA.Module.name
    return obj
@@ -41,7 +41,8 @@ for ns_canonical_name in pairs(NAMESPACE_DATA) do
     isSubject=ns_data.issubject,
     isContent=ns_data.content,
     isTalk=ns_data.istalk,
-    aliases=ns_data.aliases
+    aliases=ns_data.aliases,
+    canonical=ns_canonical_name,
   }
   mw_site_namespaces[ns_data.id] = ns
   mw_site_namespaces[ns_data.name] = ns


### PR DESCRIPTION
Fixes Lua errors in some Arabic pages from French Wiktioanry. Example page: https://fr.wiktionary.org/wiki/ف ت ح

The error happends in https://fr.wiktionary.org/wiki/Module:arabe, line 1313: `mw.title.makeTitle( "template",racine):getContent()`. This Lua module uses the lower case canonical name, but our Lua code `mw_site.matchNamespaceName()` can't find it because the `canonicalName` is localized name("Modèle").