### PR TITLE
add support for python 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "lxml",
     "psutil",
     "requests",
+    "importlib_resources; python_version < '3.10'"
 ]
 
 [project.optional-dependencies]

--- a/wikitextprocessor/common.py
+++ b/wikitextprocessor/common.py
@@ -4,7 +4,11 @@
 
 import re
 from typing import Iterator, Dict
-
+import sys
+if sys.version_info < (3, 9):
+    from typing import Pattern, Match
+else:
+    Pattern, Match = re.Pattern, re.Match
 
 # Character range used for marking magic sequences.  This package
 # assumes that these characters do not occur on Wikitext pages.  These
@@ -49,13 +53,13 @@ _nowiki_map: Dict[str, str] = {
     "'": "&apos;",
     "_": "&#95;",  # wikitext __MAGIC_WORDS__
 }
-_nowiki_re: re.Pattern[str] = re.compile(
+_nowiki_re: Pattern[str] = re.compile(
                                  "|".join(
                                   re.escape(x) for x in _nowiki_map.keys()))
 
 def nowiki_quote(text: str) -> str:
     """Quote text inside <nowiki>...</nowiki> by escaping certain characters."""
-    def _nowiki_repl(m: re.Match[str]) -> str:
+    def _nowiki_repl(m: Match[str]) -> str:
         return _nowiki_map[m.group(0)]
 
     return re.sub(_nowiki_re, _nowiki_repl, text)

--- a/wikitextprocessor/core.py
+++ b/wikitextprocessor/core.py
@@ -13,10 +13,13 @@ import sqlite3
 import sys
 import tempfile
 import urllib.parse
-from collections.abc import Sequence
+import sys
+if sys.version_info < (3, 9):
+    from typing import Sequence
+else:
+    from collections.abc import Sequence
 from dataclasses import dataclass
 from functools import lru_cache
-import sys
 if sys.version_info < (3, 10):
     from importlib_resources import files
 else:

--- a/wikitextprocessor/core.py
+++ b/wikitextprocessor/core.py
@@ -1034,20 +1034,19 @@ class Wtp:
         # refer to them
         while len(expand_stack) > 0:
             page = expand_stack.pop()
-            title_no_ns_perfix = page.title.removeprefix(
-                template_ns_local_name + ":"
-            )
-            if title_no_ns_perfix not in included_map:
+            prefix = template_ns_local_name + ":"
+            title_no_ns_prefix = page.title[len(prefix):] if page.title.startswith(prefix) else page.title
+            if title_no_ns_prefix not in included_map:
                 if self.lang_code == "zh":
-                    title_no_ns_perfix = (
-                        title_no_ns_perfix[0].lower() + title_no_ns_perfix[1:]
+                    title_no_ns_prefix = (
+                        title_no_ns_prefix[0].lower() + title_no_ns_prefix[1:]
                     )
-                    if title_no_ns_perfix not in included_map:
+                    if title_no_ns_prefix not in included_map:
                         continue
                 else:
                     continue
 
-            for template_title in included_map[title_no_ns_perfix]:
+            for template_title in included_map[title_no_ns_prefix]:
                 self.get_page.cache_clear()  # avoid infinite loop
                 template = self.get_page(template_title, template_ns_id)
                 if not template or template.need_pre_expand:
@@ -1945,10 +1944,8 @@ def is_chinese_subtitle_template(wtp: Wtp, title: str) -> bool:
     # and their titles are usually starts with "-" or "="
     template_ns = wtp.NAMESPACE_DATA.get("Template", {"name": None})
     template_ns_local_name = template_ns.get("name")
-    if template_ns_local_name:
-        title_no_prefix = title.removeprefix(template_ns_local_name + ":")
-    else:
-        title_no_prefix = title
+    prefix = template_ns_local_name + ":" if template_ns_local_name else ""
+    title_no_prefix = title[len(prefix):] if title.startswith(prefix) else title
     for token in ["-", "="]:
         if title_no_prefix.startswith(token) and title_no_prefix.endswith(
             token

--- a/wikitextprocessor/core.py
+++ b/wikitextprocessor/core.py
@@ -287,7 +287,7 @@ class Wtp:
     @property
     def backup_db_path(self) -> Path:
         assert self.db_path
-        return self.db_path.with_stem(self.db_path.stem + "_backup")
+        return self.db_path.with_name(self.db_path.stem + "_backup" + self.db_path.suffix)
 
     def backup_db(self) -> None:
         self.backup_db_path.unlink(True)

--- a/wikitextprocessor/core.py
+++ b/wikitextprocessor/core.py
@@ -16,7 +16,11 @@ import urllib.parse
 from collections.abc import Sequence
 from dataclasses import dataclass
 from functools import lru_cache
-from importlib.resources import files
+import sys
+if sys.version_info < (3, 10):
+    from importlib_resources import files
+else:
+    from importlib.resources import files
 from pathlib import Path
 from types import TracebackType
 from typing import (

--- a/wikitextprocessor/core.py
+++ b/wikitextprocessor/core.py
@@ -15,9 +15,11 @@ import tempfile
 import urllib.parse
 import sys
 if sys.version_info < (3, 9):
-    from typing import Sequence
+    from typing import Sequence, Type
+    BaseExceptionType = Type[BaseException]
 else:
     from collections.abc import Sequence
+    BaseExceptionType = type[BaseException]
 from dataclasses import dataclass
 from functools import lru_cache
 if sys.version_info < (3, 10):
@@ -152,7 +154,7 @@ class BegLineDisableManager(object):
 
     def __exit__(
         self,
-        exc_type: type[BaseException],
+        exc_type: BaseExceptionType,
         exc_value: BaseException,
         trace: TracebackType,
     ) -> None:

--- a/wikitextprocessor/luaexec.py
+++ b/wikitextprocessor/luaexec.py
@@ -853,8 +853,13 @@ def call_lua_sandbox(
         "</strong>".format(msg, html.escape(modname), html.escape(modfn))
     )
 
+def cache_decorator_with_python_version_check(func:Callable):
+    if sys.version_info < (3, 9):
+        return functools.lru_cache(maxsize=None)(func)
+    else:
+        return functools.cache(func)
 
-@functools.cache
+@cache_decorator_with_python_version_check
 def query_wikidata(item_id: str) -> Optional[dict]:
     import requests
 

--- a/wikitextprocessor/luaexec.py
+++ b/wikitextprocessor/luaexec.py
@@ -11,7 +11,11 @@ import multiprocessing  # XXX debug, remove me
 import re
 import traceback
 import unicodedata
-from importlib.resources import files
+import sys
+if sys.version_info < (3, 10):
+    from importlib_resources import files
+else:
+    from importlib.resources import files
 from typing import (
     TYPE_CHECKING,
     Any,

--- a/wikitextprocessor/parser.py
+++ b/wikitextprocessor/parser.py
@@ -5,7 +5,13 @@ import enum
 import html
 import re
 from collections import defaultdict
-from collections.abc import Iterator
+import sys
+if sys.version_info < (3, 9):
+    from typing import (
+       Iterator
+    )
+else:
+    from collections.abc import Iterator
 from typing import (
     TYPE_CHECKING,
     Callable,

--- a/wikitextprocessor/parserfns.py
+++ b/wikitextprocessor/parserfns.py
@@ -17,7 +17,11 @@ from typing import (
     Union,
 )
 
-from collections.abc import Callable
+import sys
+if sys.version_info < (3, 9):
+    from typing import Callable
+else:
+    from collections.abc import Callable
 
 from .wikihtml import ALLOWED_HTML_TAGS
 from .common import nowiki_quote, MAGIC_NOWIKI_CHAR


### PR DESCRIPTION
In wikitextprocessor/core.py `from importlib.resources import files` is used. This is a Python 3.9 feature. It should either be replaced or Python 3.9 should be specified as a requirement as done via this commit.