### PR TITLE
drop support for python 3.8 and require 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -37,6 +36,7 @@ classifiers = [
     "Topic :: Text Processing",
     "Topic :: Text Processing :: Linguistic",
 ]
+requires-python = ">=3.9"
 dependencies = [
     "dateparser",
     "lupa @ git+https://github.com/scoder/lupa.git",


### PR DESCRIPTION
Currently, the code is not compatible with python 3.8, since 3.9 features are frequently used. This commit drops support for python 3.8 and requires python 3.9 via pyproject.toml.