### PR TITLE
Fix order of flags in install instructions for test environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ python -m pip install wikitextprocessor
 
 This package includes tests written using the `unittest` framework.
 They can be run using, for example, `nose2`, which can be installed
-using `python -m pip install -e --use-pep517 ".[dev]"`.
+using `python -m pip install --use-pep517 -e ".[dev]"`.
 
 To run the tests, use the following command in the top-level directory:
 


### PR DESCRIPTION
Having the -e flag before the --use-pep517 flag causes the error:

ERROR: --use-pep517 is not a valid editable requirement. It should either be a path to a local project or a VCS URL (beginning with bzr+http, bzr+https, bzr+ssh, bzr+sftp, bzr+ftp, bzr+lp, bzr+file, git+http, git+https, git+ssh, git+git, git+file, hg+file, hg+http, hg+https, hg+ssh, hg+static-http, svn+ssh, svn+http, svn+https, svn+svn, svn+file).