### PR TITLE
Fix some Python warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
         with:
@@ -33,10 +33,10 @@ jobs:
           python -m pip install -U pip
           python -m pip install --use-pep517 '.[dev]'
       - run: make test
-      - uses: actions/upload-pages-artifact@v1
-        if: github.ref_name == 'main' && matrix.python-version == '3.11'
-        with:
-          path: htmlcov
+      # - uses: actions/upload-pages-artifact@v2
+      #   if: github.ref_name == 'main' && matrix.python-version == '3.12'
+      #   with:
+      #     path: htmlcov
 
   # deploy:
   #   if: github.ref_name == 'main'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,8 @@ jobs:
           python -m pip install -U pip
           python -m pip install --use-pep517 '.[dev]'
       - run: make test
+        env:
+          PYTHONWARNINGS: default
       # - uses: actions/upload-pages-artifact@v2
       #   if: github.ref_name == 'main' && matrix.python-version == '3.12'
       #   with:

--- a/wikitextprocessor/core.py
+++ b/wikitextprocessor/core.py
@@ -1496,8 +1496,7 @@ class Wtp:
                         arg = str(args[i])
                         k: Union[str, int]
                         m2 = re.match(
-                            r"""(?s)^\s*([^][&<>="']+?)\s*="""
-                            """\s*(.*?)\s*$""",
+                            r"""(?s)^\s*([^][&<>="']+?)\s*=\s*(.*?)\s*$""",
                             arg,
                         )
                         if m2:

--- a/wikitextprocessor/parserfns.py
+++ b/wikitextprocessor/parserfns.py
@@ -46,7 +46,7 @@ def if_fn(ctx: "Wtp", fn_name: str,
           expander: Callable[[str], str]
          ) -> str:
     """Implements #if parser function."""
-    # print(f"if_fn: {args}") 
+    # print(f"if_fn: {args}")
     arg0: str = args[0] if args else ""
     arg1: str = args[1] if len(args) >= 2 else ""
     arg2: str = args[2] if len(args) >= 3 else ""
@@ -469,7 +469,7 @@ def currentyear_fn(
     expander: Callable[[str], str]
 ) -> str:
     """Implements the CURRENTYEAR magic word."""
-    return str(datetime.datetime.utcnow().year)
+    return str(datetime.datetime.now(datetime.timezone.utc).year)
 
 
 def currentmonth_fn(
@@ -479,7 +479,7 @@ def currentmonth_fn(
     expander: Callable[[str], str]
 ) -> str:
     """Implements the CURRENTMONTH magic word."""
-    return "{:02d}".format(datetime.datetime.utcnow().month)
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%m")
 
 
 def currentmonth1_fn(
@@ -489,7 +489,7 @@ def currentmonth1_fn(
     expander: Callable[[str], str]
 ) -> str:
     """Implements the CURRENTMONTH1 magic word."""
-    return "{:d}".format(datetime.datetime.utcnow().month)
+    return str(datetime.datetime.now(datetime.timezone.utc).month)
 
 
 def currentmonthname_fn(
@@ -500,10 +500,7 @@ def currentmonthname_fn(
 ) -> str:
     """Implements the CURRENTMONTHNAME magic word."""
     # XXX support for other languages?
-    month = datetime.datetime.utcnow().month
-    return ("", "January", "February", "March", "April", "May", "June",
-            "July", "August", "September", "October", "November",
-            "December")[month]
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%B")
 
 
 def currentmonthabbrev_fn(
@@ -514,9 +511,7 @@ def currentmonthabbrev_fn(
 ) -> str:
     """Implements the CURRENTMONTHABBREV magic word."""
     # XXX support for other languages?
-    month = datetime.datetime.utcnow().month
-    return ("", "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-            "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")[month]
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%b")
 
 
 def currentday_fn(
@@ -526,7 +521,7 @@ def currentday_fn(
     expander: Callable[[str], str]
 ) -> str:
     """Implements the CURRENTDAY magic word."""
-    return "{:d}".format(datetime.datetime.utcnow().day)
+    return str(datetime.datetime.now(datetime.timezone.utc).day)
 
 
 def currentday2_fn(
@@ -536,7 +531,7 @@ def currentday2_fn(
     expander: Callable[[str], str]
 ) -> str:
     """Implements the CURRENTDAY2 magic word."""
-    return "{:02d}".format(datetime.datetime.utcnow().day)
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%d")
 
 
 def currentdow_fn(
@@ -546,7 +541,7 @@ def currentdow_fn(
     expander: Callable[[str], str]
 ) -> str:
     """Implements the CURRENTDOW magic word."""
-    return "{:d}".format(datetime.datetime.utcnow().weekday())
+    return str(datetime.datetime.now(datetime.timezone.utc).weekday())
 
 
 def revisionid_fn(
@@ -1356,7 +1351,7 @@ def time_fn(
         # people on wiktionary don't go crazy with weird formatting
         t = dateparser.parse(dt, settings=settings)
         if t is None:
-            m = re.match(r"([^+]*)\s*(\+\s*\d+\s*(day|year|month)s?)\s*$", 
+            m = re.match(r"([^+]*)\s*(\+\s*\d+\s*(day|year|month)s?)\s*$",
                          orig_dt)
             if m:
                 main_date = dateparser.parse(m.group(1), settings=settings)


### PR DESCRIPTION
- Add tests for Python 3.9 and 3.12
- Don't hide Deprecation warnings in tests
- Fix a regex bug in https://github.com/tatuylonen/wikitextprocessor/commit/6feffe33c84b92e145f4a304bf1080014e62ed4a
- Replace some date format code with `datetime.strftime()`
- Replace deprecated `datetime.utcnow()`