### PR TITLE
Add GitHub dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,8 @@ name: Lint
 on:
   workflow_dispatch:
   push:
+    branches:
+      - '*'
   pull_request:
 
 permissions:


### PR DESCRIPTION
[Dependabot](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-supply-chain-security#what-is-dependabot)  creates pull-requests automatically that keeps GitHub Actions dependencies up-to-date. It can be enabled in the project's settings page's "Code security and analysis" section.
