### PR TITLE
Fix regex characters range "A-Z"

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -534,7 +534,7 @@ class Wtp:
                     # re.X = ignore whitespace and comments, re.I = ignore case
                     r"""(?xi)\|(
                             (
-                                <([-a-zA-z0-9]+)\b[^>]*>  # html tag
+                                <([-a-zA-Z0-9]+)\b[^>]*>  # html tag
                                     [^][{}]*?             # element contents
                                                           # (including `|`'s)
                                     </\3\s*>              # end tag


### PR DESCRIPTION
This error was found by GitHub Code Scan, here is the screenshot from my forked repo:

<details>
<summary>screenshot</summary>

![image](https://github.com/tatuylonen/wikitextprocessor/assets/21101839/a49e15e8-28a6-47a2-b819-745381667020)
</details>