### PR TITLE
Add an option to skip analyzing templates

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -135,7 +135,7 @@ class Page:
     model: Optional[str] = None
 
 
-class BegLineDisableManager(object):
+class BegLineDisableManager:
     """A 'context manager'-style object to use with `with` that increments
     and decrements a counter used as a flag to see whether the parser
     should care about tokens at the beginning of a line, used in magic_fn
@@ -980,33 +980,15 @@ class Wtp:
         logging.info(
             "Analyzing which templates should be expanded before parsing"
         )
-        # Add/overwrite templates
-        template_ns: NamespaceDataEntry = self.NAMESPACE_DATA.get(
-            "Template", EMPTY_NAMESPACEDATA
-        )
-        template_ns_id = template_ns["id"]
-        template_ns_local_name = template_ns["name"]
-        self.add_page(
-            f"{template_ns_local_name}:!", template_ns_id, "|"
-        )  # magic word
-        self.add_page(
-            f"{template_ns_local_name}:((", template_ns_id, "&lbrace;&lbrace;"
-        )  # {{((}} -> {{
-        self.add_page(
-            f"{template_ns_local_name}:))", template_ns_id, "&rbrace;&rbrace;"
-        )  # {{))}} -> }}
-
+        template_ns_data = self.NAMESPACE_DATA.get("Template")
+        template_ns_id = template_ns_data["id"]
+        template_ns_local_name = template_ns_data["name"]
         expand_stack: List[Page] = []
         # the keys of included_map are template names without
         # the namespace prefix
         included_map: DefaultDict[str, Set[str]] = collections.defaultdict(set)
 
-        if template_ns_id:
-            template_ns_id_list: Optional[List[int]] = [template_ns_id]
-        else:
-            template_ns_id_list = None
-
-        for page in self.get_all_pages(template_ns_id_list):
+        for page in self.get_all_pages([template_ns_id]):
             if page.body is not None:
                 used_templates, pre_expand = self._analyze_template(
                     page.title, page.body

--- a/tests/test_wikiprocess.py
+++ b/tests/test_wikiprocess.py
@@ -15,6 +15,9 @@ from wikitextprocessor.common import MAGIC_NOWIKI_CHAR
 class WikiProcTests(unittest.TestCase):
     def setUp(self) -> None:
         self.ctx = Wtp()
+        self.ctx.add_page("Template:!", 10, "|")
+        self.ctx.add_page("Template:((", 10, "&lbrace;&lbrace;")
+        self.ctx.add_page("Template:))", 10, "&rbrace;&rbrace;")
 
     def tearDown(self) -> None:
         self.ctx.close_db_conn()
@@ -1551,7 +1554,6 @@ MORE
 
     def test_template24a(self):
         self.ctx.add_page("Template:template", 10, "a{{{1}}}b")
-        self.ctx.analyze_templates()
         self.ctx.start_page("Tt")
         ret = self.ctx.expand("{{template|{{!}}}}")
         self.assertEqual(ret, "a|b")
@@ -1564,7 +1566,6 @@ MORE
         self.assertEqual(ret, "a|-b")
 
     def test_template24c(self):
-        self.ctx.analyze_templates()
         self.ctx.start_page("Tt")
         ret = self.ctx.expand(
             "{{#if:true|before{{#if:true|{{!}}|false}}after}}"
@@ -1575,7 +1576,6 @@ MORE
         self.ctx.add_page(
             "Template:t1", 10, "before{{#if:true|{{!}}|false}}after"
         )
-        self.ctx.analyze_templates()
         self.ctx.start_page("Tt")
         ret = self.ctx.expand("{{#if:true|{{t1}}}}")
         self.assertEqual(ret, "before|after")
@@ -1584,7 +1584,6 @@ MORE
         self.ctx.add_page(
             "Template:t1", 10, "before{{#if:true|{{!}}|false}}after"
         )
-        self.ctx.analyze_templates()
         self.ctx.start_page("Tt")
         ret = self.ctx.expand("{|\n||first||{{t1}}||last\n|}")
         self.assertEqual(ret, "{|\n||first||before|after||last\n|}")
@@ -1592,7 +1591,6 @@ MORE
     def test_template24f(self):
         self.ctx.add_page("Template:row", 10, "||bar\n{{!}} {{!}}baz\n| zap")
         self.ctx.add_page("Template:t1", 10, "{|\n! Hdr\n{{row|foo}}\n|}")
-        self.ctx.analyze_templates()
         self.ctx.start_page("Tt")
         ret = self.ctx.expand("{{t1}}")
         self.assertEqual(ret, "{|\n! Hdr\n||bar\n| |baz\n| zap\n|}")
@@ -1602,7 +1600,6 @@ MORE
         # https://www.mediawiki.org/wiki/Extension:Scribunto/Lua_reference_manual#frame:getTitle,
         # under frame:expandTemplate examples
         self.ctx.add_page("Template:template", 10, "a{{{1}}}b")
-        self.ctx.analyze_templates()
         self.ctx.start_page("Tt")
         ret = self.ctx.expand("{{template|{{((}}!{{))}}}}")
         self.assertEqual(ret, "a&lbrace;&lbrace;!&rbrace;&rbrace;b")


### PR DESCRIPTION
Pre-expand templates is not very useful for the French Wiktionary. For example, translation start template "trad-début" doesn't need to be expanded and it's sense parameter would be lost if expanded. And it also moves the translation list nodes inside some HTML tags.