### PR TITLE
Match latex math formula in template parameters

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -700,10 +700,9 @@ class Wtp:
             # Replace template invocation
             text = re.sub(
                 r"\{" + MAGIC_NOWIKI_CHAR + r"?\{((?:"
-                r"[^{}](?:\{[^{}|])?|"  # lone possible { and also default "any"
-                r"\{\|[^{}]*?\|\}|"  # Outer table tokens
-                r"\}(?=[^{}])|"  # lone `}`, (?=...) is not consumed (lookahead)
-                r"-\{}-|"  # GitHub issue #59 Chinese wiktionary special `-{}-`
+                r"[^{}]|"  # any character except brackets
+                r"-{}-|"  # GitHub issue #59 Chinese wiktionary special `-{}-`
+                r"{[^{}]+}|"  # latex argument: "<math>\frac{1}{2}</math>"
                 r")+?)\}" + MAGIC_NOWIKI_CHAR + r"?\}",
                 repl_templ,
                 text,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2417,6 +2417,17 @@ def foo(x):
         self.assertTrue(isinstance(node, TemplateNode))
         self.assertEqual(node.template_name, "exemple")
 
+    def test_latex_math_tag_template_parameter(self):
+        # https://en.wiktionary.org/wiki/antisymmetric
+        tree = self.parse("", "{{quote-book|en|<math>\\frac{1}{2}</math>}}")
+        template_node = tree.children[0]
+        self.assertTrue(isinstance(template_node, TemplateNode))
+        self.assertEqual(template_node.template_name, "quote-book")
+        self.assertEqual(
+            template_node.template_parameters,
+            {1: "en", 2: "<math>\\frac{1}{2}</math>"}
+        )
+
 
 # XXX implement <nowiki/> marking for links, templates
 #  - https://en.wikipedia.org/wiki/Help:Wikitext#Nowiki


### PR DESCRIPTION
Previous template regex pattern can't match templates with parameter that has a "{" right after "}". Also remove the table pattern to keep the pattern simple, tables are never used in template parameters.

Resolves https://github.com/tatuylonen/wiktextract/issues/365.

Pray this change won't break anything...