### PR TITLE
Restore regex patterns match unpaired "{" and "}" in template body

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -700,9 +700,10 @@ class Wtp:
             # Replace template invocation
             text = re.sub(
                 r"\{" + MAGIC_NOWIKI_CHAR + r"?\{((?:"
-                r"[^{}]|"  # any character except brackets
+                r"[^{}](?:{[^{}])?|"  # lone possible { and also default "any"
+                r"}(?=[^{}])|"  # lone `}`, (?=...) is not consumed (lookahead)
                 r"-{}-|"  # GitHub issue #59 Chinese wiktionary special `-{}-`
-                r"{[^{}]+}|"  # latex argument: "<math>\frac{1}{2}</math>"
+                r"}{|"  # latex argument: "<math>\frac{1}{2}</math>"
                 r")+?)\}" + MAGIC_NOWIKI_CHAR + r"?\}",
                 repl_templ,
                 text,
@@ -1393,11 +1394,11 @@ class Wtp:
                     tname = re.sub(r"<noinclude\s*/>", "", tname)
 
                     # Strip safesubst: and subst: prefixes
-                    tname = tname.strip()
-                    if tname[:10].lower() == "safesubst:":
-                        tname = tname[10:]
-                    elif tname[:6].lower() == "subst:":
-                        tname = tname[6:]
+                    tname = (
+                        tname.strip()
+                        .removeprefix("subst:")
+                        .removeprefix("safesubst:")
+                    )
 
                     # Check if it is a parser function call
                     ofs = tname.find(":")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2428,6 +2428,11 @@ def foo(x):
             {1: "en", 2: "<math>\\frac{1}{2}</math>"}
         )
 
+    def test_match_template_contains_unpaired_curly_brackets(self):
+        # https://en.wiktionary.org/wiki/Template:str_index-lite/logic
+        tree = self.parse("", "{{#switch:foo|*foo{*={|*bar}*=}|-}}")
+        parser_function_node = tree.children[0]
+        self.assertEqual(parser_function_node.kind, NodeKind.PARSER_FN)
 
 # XXX implement <nowiki/> marking for links, templates
 #  - https://en.wikipedia.org/wiki/Help:Wikitext#Nowiki


### PR DESCRIPTION
Commit f815e426ddf4a8818182662af84cf11d72e4cc1a removes these two patterns causes the code can't match the `#switch` parser function in template "str index-lite/logic" and generates a very long expanded text, then triggers regex exponential backtracking at file clean.py line 1444.