### PR TITLE
Fix two catastrophic backtracking cases when matching wikitext table

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -838,7 +838,7 @@ class Wtp:
                     (^|\n) \{\|               # start of line {|
                         (    [^\n]            # any except newline
                         |    \n+[^{|]         # any except { or | at line start
-                        |    \n+\|[^}]        # | + any except } at linestart
+                        |    \n+\|[^}]?       # | + any except } at linestart
                         |    \n+\{[^|]        # { + any except | at linestart
                         )*?
                     \n+\s*\|\}                # |}""",

--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -841,7 +841,7 @@ class Wtp:
                         |    \n+\|[^}]        # | + any except } at linestart
                         |    \n+\{[^|]        # { + any except | at linestart
                         )*?
-                    \n+\|\}                   # |}""",
+                    \n+\s*\|\}                # |}""",
                 "",
                 prev,
             )


### PR DESCRIPTION
This bug was found in https://github.com/tatuylonen/wiktextract/issues/389, but this pr only fixes two cases. `Wtp._analyze_template()` sill has more backtracking bugs while processing the Russian Wikipedia templates. The code now stuck at page https://ru.wikipedia.org/wiki/Шаблон:Результаты_зимних_Олимпийских_игр_2006, this template seems to use the `{{!}}` template at the end of the table.