### PR TITLE
Update Spanish namespace data

### DIFF
--- a/src/wikitextprocessor/data/es/namespaces.json
+++ b/src/wikitextprocessor/data/es/namespaces.json
@@ -1,1 +1,386 @@
-{"Media": {"id": -2, "name": "Medio", "content": false, "aliases": [], "issubject": true, "istalk": false}, "Special": {"id": -1, "name": "Especial", "content": false, "aliases": [], "issubject": true, "istalk": false}, "Main": {"id": 0, "name": "Main", "content": true, "aliases": [], "issubject": true, "istalk": false}, "Talk": {"id": 1, "name": "Discusi\u00f3n", "content": false, "aliases": [], "issubject": false, "istalk": true}, "User": {"id": 2, "name": "Usuaria", "content": false, "aliases": ["Usuario"], "issubject": true, "istalk": false}, "User talk": {"id": 3, "name": "Usuaria Discusi\u00f3n", "content": false, "aliases": ["Usuario discusi\u00f3n", "Usuario Discusi\u00f3n"], "issubject": false, "istalk": true}, "Project": {"id": 4, "name": "Wikipedia", "content": false, "aliases": ["WT"], "issubject": true, "istalk": false}, "Project talk": {"id": 5, "name": "Wikipedia discusi\u00f3n", "content": false, "aliases": [], "issubject": false, "istalk": true}, "File": {"id": 6, "name": "Archivo", "content": false, "aliases": ["Image"], "issubject": true, "istalk": false}, "File talk": {"id": 7, "name": "Archivo discusi\u00f3n", "content": false, "aliases": ["Image talk"], "issubject": false, "istalk": true}, "MediaWiki": {"id": 8, "name": "MediaWiki", "content": false, "aliases": [], "issubject": true, "istalk": false}, "MediaWiki talk": {"id": 9, "name": "MediaWiki discusi\u00f3n", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Template": {"id": 10, "name": "Plantilla", "content": false, "aliases": ["T"], "issubject": true, "istalk": false}, "Template talk": {"id": 11, "name": "Plantilla discusi\u00f3n", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Help": {"id": 12, "name": "Ayuda", "content": false, "aliases": [], "issubject": true, "istalk": false}, "Help talk": {"id": 13, "name": "Ayuda discusi\u00f3n", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Category": {"id": 14, "name": "Categor\u00eda", "content": false, "aliases": ["CAT"], "issubject": true, "istalk": false}, "Category talk": {"id": 15, "name": "Categor\u00eda discusi\u00f3n", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Thread": {"id": 90, "name": "Thread", "content": false, "aliases": [], "issubject": true, "istalk": false}, "Thread talk": {"id": 91, "name": "Thread talk", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Summary": {"id": 92, "name": "Summary", "content": false, "aliases": [], "issubject": true, "istalk": false}, "Summary talk": {"id": 93, "name": "Summary talk", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Appendix": {"id": 100, "name": "Appendix", "content": false, "aliases": ["AP"], "issubject": true, "istalk": false}, "Appendix talk": {"id": 101, "name": "Appendix talk", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Concordance": {"id": 102, "name": "Concordance", "content": false, "aliases": [], "issubject": true, "istalk": false}, "Concordance talk": {"id": 103, "name": "Concordance talk", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Index": {"id": 104, "name": "Index", "content": false, "aliases": [], "issubject": true, "istalk": false}, "Index talk": {"id": 105, "name": "Index talk", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Rhymes": {"id": 106, "name": "Rhymes", "content": false, "aliases": [], "issubject": true, "istalk": false}, "Rhymes talk": {"id": 107, "name": "Rhymes talk", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Transwiki": {"id": 108, "name": "Transwiki", "content": false, "aliases": [], "issubject": true, "istalk": false}, "Transwiki talk": {"id": 109, "name": "Transwiki talk", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Thesaurus": {"id": 110, "name": "Thesaurus", "content": false, "aliases": ["WS", "Wikisaurus"], "issubject": true, "istalk": false}, "Thesaurus talk": {"id": 111, "name": "Thesaurus talk", "content": false, "aliases": ["Wikisaurus talk"], "issubject": false, "istalk": true}, "Citations": {"id": 114, "name": "Citations", "content": false, "aliases": [], "issubject": true, "istalk": false}, "Citations talk": {"id": 115, "name": "Citations talk", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Sign gloss": {"id": 116, "name": "Sign gloss", "content": false, "aliases": [], "issubject": true, "istalk": false}, "Sign gloss talk": {"id": 117, "name": "Sign gloss talk", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Reconstruction": {"id": 118, "name": "Reconstruction", "content": false, "aliases": ["RC"], "issubject": true, "istalk": false}, "Reconstruction talk": {"id": 119, "name": "Reconstruction talk", "content": false, "aliases": [], "issubject": false, "istalk": true}, "TimedText": {"id": 710, "name": "TimedText", "content": false, "aliases": [], "issubject": true, "istalk": false}, "TimedText talk": {"id": 711, "name": "TimedText talk", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Module": {"id": 828, "name": "M\u00f3dulo", "content": false, "aliases": ["MOD"], "issubject": true, "istalk": false}, "Module talk": {"id": 829, "name": "M\u00f3dulo discusi\u00f3n", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Gadget": {"id": 2300, "name": "Gadget", "content": false, "aliases": [], "issubject": true, "istalk": false}, "Gadget talk": {"id": 2301, "name": "Gadget talk", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Gadget definition": {"id": 2302, "name": "Gadget definition", "content": false, "aliases": [], "issubject": true, "istalk": false}, "Gadget definition talk": {"id": 2303, "name": "Gadget definition talk", "content": false, "aliases": [], "issubject": false, "istalk": true}}
+{
+  "Media": {
+    "id": -2,
+    "name": "Medio",
+    "content": false,
+    "aliases": [],
+    "issubject": true,
+    "istalk": false
+  },
+  "Special": {
+    "id": -1,
+    "name": "Especial",
+    "content": false,
+    "aliases": [],
+    "issubject": true,
+    "istalk": false
+  },
+  "Main": {
+    "id": 0,
+    "name": "Main",
+    "content": true,
+    "aliases": [],
+    "issubject": true,
+    "istalk": false
+  },
+  "Talk": {
+    "id": 1,
+    "name": "Discusi\u00f3n",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "User": {
+    "id": 2,
+    "name": "Usuaria",
+    "content": false,
+    "aliases": ["Usuario"],
+    "issubject": true,
+    "istalk": false
+  },
+  "User talk": {
+    "id": 3,
+    "name": "Usuaria Discusi\u00f3n",
+    "content": false,
+    "aliases": ["Usuario discusi\u00f3n", "Usuario Discusi\u00f3n"],
+    "issubject": false,
+    "istalk": true
+  },
+  "Project": {
+    "id": 4,
+    "name": "Wikipedia",
+    "content": false,
+    "aliases": ["WT"],
+    "issubject": true,
+    "istalk": false
+  },
+  "Project talk": {
+    "id": 5,
+    "name": "Wikipedia discusi\u00f3n",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "File": {
+    "id": 6,
+    "name": "Archivo",
+    "content": false,
+    "aliases": ["Image"],
+    "issubject": true,
+    "istalk": false
+  },
+  "File talk": {
+    "id": 7,
+    "name": "Archivo discusi\u00f3n",
+    "content": false,
+    "aliases": ["Image talk"],
+    "issubject": false,
+    "istalk": true
+  },
+  "MediaWiki": {
+    "id": 8,
+    "name": "MediaWiki",
+    "content": false,
+    "aliases": [],
+    "issubject": true,
+    "istalk": false
+  },
+  "MediaWiki talk": {
+    "id": 9,
+    "name": "MediaWiki discusi\u00f3n",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "Template": {
+    "id": 10,
+    "name": "Plantilla",
+    "content": false,
+    "aliases": ["T"],
+    "issubject": true,
+    "istalk": false
+  },
+  "Template talk": {
+    "id": 11,
+    "name": "Plantilla discusi\u00f3n",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "Help": {
+    "id": 12,
+    "name": "Ayuda",
+    "content": false,
+    "aliases": [],
+    "issubject": true,
+    "istalk": false
+  },
+  "Help talk": {
+    "id": 13,
+    "name": "Ayuda discusi\u00f3n",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "Category": {
+    "id": 14,
+    "name": "Categor\u00eda",
+    "content": false,
+    "aliases": ["CAT"],
+    "issubject": true,
+    "istalk": false
+  },
+  "Category talk": {
+    "id": 15,
+    "name": "Categor\u00eda discusi\u00f3n",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "Thread": {
+    "id": 90,
+    "name": "Thread",
+    "content": false,
+    "aliases": [],
+    "issubject": true,
+    "istalk": false
+  },
+  "Thread talk": {
+    "id": 91,
+    "name": "Thread talk",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "Summary": {
+    "id": 92,
+    "name": "Summary",
+    "content": false,
+    "aliases": [],
+    "issubject": true,
+    "istalk": false
+  },
+  "Summary talk": {
+    "id": 93,
+    "name": "Summary talk",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "Appendix": {
+    "id": 100,
+    "name": "Appendix",
+    "content": false,
+    "aliases": ["AP"],
+    "issubject": true,
+    "istalk": false
+  },
+  "Appendix talk": {
+    "id": 101,
+    "name": "Appendix talk",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "Concordance": {
+    "id": 102,
+    "name": "Concordance",
+    "content": false,
+    "aliases": [],
+    "issubject": true,
+    "istalk": false
+  },
+  "Concordance talk": {
+    "id": 103,
+    "name": "Concordance talk",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "Index": {
+    "id": 104,
+    "name": "Index",
+    "content": false,
+    "aliases": [],
+    "issubject": true,
+    "istalk": false
+  },
+  "Index talk": {
+    "id": 105,
+    "name": "Index talk",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "Rhymes": {
+    "id": 106,
+    "name": "Rhymes",
+    "content": false,
+    "aliases": [],
+    "issubject": true,
+    "istalk": false
+  },
+  "Rhymes talk": {
+    "id": 107,
+    "name": "Rhymes talk",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "Transwiki": {
+    "id": 108,
+    "name": "Transwiki",
+    "content": false,
+    "aliases": [],
+    "issubject": true,
+    "istalk": false
+  },
+  "Transwiki talk": {
+    "id": 109,
+    "name": "Transwiki talk",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "Thesaurus": {
+    "id": 110,
+    "name": "Thesaurus",
+    "content": false,
+    "aliases": ["WS", "Wikisaurus"],
+    "issubject": true,
+    "istalk": false
+  },
+  "Thesaurus talk": {
+    "id": 111,
+    "name": "Thesaurus talk",
+    "content": false,
+    "aliases": ["Wikisaurus talk"],
+    "issubject": false,
+    "istalk": true
+  },
+  "Citations": {
+    "id": 114,
+    "name": "Citations",
+    "content": false,
+    "aliases": [],
+    "issubject": true,
+    "istalk": false
+  },
+  "Citations talk": {
+    "id": 115,
+    "name": "Citations talk",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "Sign gloss": {
+    "id": 116,
+    "name": "Sign gloss",
+    "content": false,
+    "aliases": [],
+    "issubject": true,
+    "istalk": false
+  },
+  "Sign gloss talk": {
+    "id": 117,
+    "name": "Sign gloss talk",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "Reconstruction": {
+    "id": 118,
+    "name": "Reconstruction",
+    "content": false,
+    "aliases": ["RC"],
+    "issubject": true,
+    "istalk": false
+  },
+  "Reconstruction talk": {
+    "id": 119,
+    "name": "Reconstruction talk",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "TimedText": {
+    "id": 710,
+    "name": "TimedText",
+    "content": false,
+    "aliases": [],
+    "issubject": true,
+    "istalk": false
+  },
+  "TimedText talk": {
+    "id": 711,
+    "name": "TimedText talk",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "Module": {
+    "id": 828,
+    "name": "M\u00f3dulo",
+    "content": false,
+    "aliases": ["MOD"],
+    "issubject": true,
+    "istalk": false
+  },
+  "Module talk": {
+    "id": 829,
+    "name": "M\u00f3dulo discusi\u00f3n",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "Gadget": {
+    "id": 2300,
+    "name": "Gadget",
+    "content": false,
+    "aliases": [],
+    "issubject": true,
+    "istalk": false
+  },
+  "Gadget talk": {
+    "id": 2301,
+    "name": "Gadget talk",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "Gadget definition": {
+    "id": 2302,
+    "name": "Gadget definition",
+    "content": false,
+    "aliases": [],
+    "issubject": true,
+    "istalk": false
+  },
+  "Gadget definition talk": {
+    "id": 2303,
+    "name": "Gadget definition talk",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  }
+}

--- a/src/wikitextprocessor/data/es/namespaces.json
+++ b/src/wikitextprocessor/data/es/namespaces.json
@@ -25,7 +25,7 @@
   },
   "Talk": {
     "id": 1,
-    "name": "Discusi\u00f3n",
+    "name": "Discusión",
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -33,33 +33,33 @@
   },
   "User": {
     "id": 2,
-    "name": "Usuaria",
+    "name": "Usuario",
     "content": false,
-    "aliases": ["Usuario"],
+    "aliases": ["Usuaria"],
     "issubject": true,
     "istalk": false
   },
   "User talk": {
     "id": 3,
-    "name": "Usuaria Discusi\u00f3n",
+    "name": "Usuario discusión",
     "content": false,
-    "aliases": ["Usuario discusi\u00f3n", "Usuario Discusi\u00f3n"],
+    "aliases": ["Usuaria discusión"],
     "issubject": false,
     "istalk": true
   },
   "Project": {
     "id": 4,
-    "name": "Wikipedia",
+    "name": "Wikcionario",
     "content": false,
-    "aliases": ["WT"],
+    "aliases": ["WN", "WT", "Wiktionary"],
     "issubject": true,
     "istalk": false
   },
   "Project talk": {
     "id": 5,
-    "name": "Wikipedia discusi\u00f3n",
+    "name": "Wikcionario discusión",
     "content": false,
-    "aliases": [],
+    "aliases": ["Wiktionary talk"],
     "issubject": false,
     "istalk": true
   },
@@ -67,15 +67,15 @@
     "id": 6,
     "name": "Archivo",
     "content": false,
-    "aliases": ["Image"],
+    "aliases": ["Image", "Imagen"],
     "issubject": true,
     "istalk": false
   },
   "File talk": {
     "id": 7,
-    "name": "Archivo discusi\u00f3n",
+    "name": "Archivo discusión",
     "content": false,
-    "aliases": ["Image talk"],
+    "aliases": ["Image talk", "Imagen discusión"],
     "issubject": false,
     "istalk": true
   },
@@ -89,7 +89,7 @@
   },
   "MediaWiki talk": {
     "id": 9,
-    "name": "MediaWiki discusi\u00f3n",
+    "name": "MediaWiki discusión",
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -99,13 +99,13 @@
     "id": 10,
     "name": "Plantilla",
     "content": false,
-    "aliases": ["T"],
+    "aliases": [],
     "issubject": true,
     "istalk": false
   },
   "Template talk": {
     "id": 11,
-    "name": "Plantilla discusi\u00f3n",
+    "name": "Plantilla discusión",
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -121,7 +121,7 @@
   },
   "Help talk": {
     "id": 13,
-    "name": "Ayuda discusi\u00f3n",
+    "name": "Ayuda discusión",
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -129,47 +129,15 @@
   },
   "Category": {
     "id": 14,
-    "name": "Categor\u00eda",
+    "name": "Categoría",
     "content": false,
-    "aliases": ["CAT"],
+    "aliases": [],
     "issubject": true,
     "istalk": false
   },
   "Category talk": {
     "id": 15,
-    "name": "Categor\u00eda discusi\u00f3n",
-    "content": false,
-    "aliases": [],
-    "issubject": false,
-    "istalk": true
-  },
-  "Thread": {
-    "id": 90,
-    "name": "Thread",
-    "content": false,
-    "aliases": [],
-    "issubject": true,
-    "istalk": false
-  },
-  "Thread talk": {
-    "id": 91,
-    "name": "Thread talk",
-    "content": false,
-    "aliases": [],
-    "issubject": false,
-    "istalk": true
-  },
-  "Summary": {
-    "id": 92,
-    "name": "Summary",
-    "content": false,
-    "aliases": [],
-    "issubject": true,
-    "istalk": false
-  },
-  "Summary talk": {
-    "id": 93,
-    "name": "Summary talk",
+    "name": "Categoría discusión",
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -177,143 +145,15 @@
   },
   "Appendix": {
     "id": 100,
-    "name": "Appendix",
+    "name": "Apéndice",
     "content": false,
-    "aliases": ["AP"],
+    "aliases": [],
     "issubject": true,
     "istalk": false
   },
-  "Appendix talk": {
+  "Appendix Discusión": {
     "id": 101,
-    "name": "Appendix talk",
-    "content": false,
-    "aliases": [],
-    "issubject": false,
-    "istalk": true
-  },
-  "Concordance": {
-    "id": 102,
-    "name": "Concordance",
-    "content": false,
-    "aliases": [],
-    "issubject": true,
-    "istalk": false
-  },
-  "Concordance talk": {
-    "id": 103,
-    "name": "Concordance talk",
-    "content": false,
-    "aliases": [],
-    "issubject": false,
-    "istalk": true
-  },
-  "Index": {
-    "id": 104,
-    "name": "Index",
-    "content": false,
-    "aliases": [],
-    "issubject": true,
-    "istalk": false
-  },
-  "Index talk": {
-    "id": 105,
-    "name": "Index talk",
-    "content": false,
-    "aliases": [],
-    "issubject": false,
-    "istalk": true
-  },
-  "Rhymes": {
-    "id": 106,
-    "name": "Rhymes",
-    "content": false,
-    "aliases": [],
-    "issubject": true,
-    "istalk": false
-  },
-  "Rhymes talk": {
-    "id": 107,
-    "name": "Rhymes talk",
-    "content": false,
-    "aliases": [],
-    "issubject": false,
-    "istalk": true
-  },
-  "Transwiki": {
-    "id": 108,
-    "name": "Transwiki",
-    "content": false,
-    "aliases": [],
-    "issubject": true,
-    "istalk": false
-  },
-  "Transwiki talk": {
-    "id": 109,
-    "name": "Transwiki talk",
-    "content": false,
-    "aliases": [],
-    "issubject": false,
-    "istalk": true
-  },
-  "Thesaurus": {
-    "id": 110,
-    "name": "Thesaurus",
-    "content": false,
-    "aliases": ["WS", "Wikisaurus"],
-    "issubject": true,
-    "istalk": false
-  },
-  "Thesaurus talk": {
-    "id": 111,
-    "name": "Thesaurus talk",
-    "content": false,
-    "aliases": ["Wikisaurus talk"],
-    "issubject": false,
-    "istalk": true
-  },
-  "Citations": {
-    "id": 114,
-    "name": "Citations",
-    "content": false,
-    "aliases": [],
-    "issubject": true,
-    "istalk": false
-  },
-  "Citations talk": {
-    "id": 115,
-    "name": "Citations talk",
-    "content": false,
-    "aliases": [],
-    "issubject": false,
-    "istalk": true
-  },
-  "Sign gloss": {
-    "id": 116,
-    "name": "Sign gloss",
-    "content": false,
-    "aliases": [],
-    "issubject": true,
-    "istalk": false
-  },
-  "Sign gloss talk": {
-    "id": 117,
-    "name": "Sign gloss talk",
-    "content": false,
-    "aliases": [],
-    "issubject": false,
-    "istalk": true
-  },
-  "Reconstruction": {
-    "id": 118,
-    "name": "Reconstruction",
-    "content": false,
-    "aliases": ["RC"],
-    "issubject": true,
-    "istalk": false
-  },
-  "Reconstruction talk": {
-    "id": 119,
-    "name": "Reconstruction talk",
+    "name": "Apéndice Discusión",
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -337,15 +177,15 @@
   },
   "Module": {
     "id": 828,
-    "name": "M\u00f3dulo",
+    "name": "Módulo",
     "content": false,
-    "aliases": ["MOD"],
+    "aliases": [],
     "issubject": true,
     "istalk": false
   },
   "Module talk": {
     "id": 829,
-    "name": "M\u00f3dulo discusi\u00f3n",
+    "name": "Módulo discusión",
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -353,7 +193,7 @@
   },
   "Gadget": {
     "id": 2300,
-    "name": "Gadget",
+    "name": "Accesorio",
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -361,7 +201,7 @@
   },
   "Gadget talk": {
     "id": 2301,
-    "name": "Gadget talk",
+    "name": "Accesorio discusión",
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -369,7 +209,7 @@
   },
   "Gadget definition": {
     "id": 2302,
-    "name": "Gadget definition",
+    "name": "Accesorio definición",
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -377,7 +217,7 @@
   },
   "Gadget definition talk": {
     "id": 2303,
-    "name": "Gadget definition talk",
+    "name": "Accesorio definición discusión",
     "content": false,
     "aliases": [],
     "issubject": false,

--- a/tools/get_namespaces.py
+++ b/tools/get_namespaces.py
@@ -63,7 +63,7 @@ def main():
             if ns_data["id"] == data["id"] and data["alias"] != ns_data["name"]:
                 ns_data["aliases"].append(data["alias"])
 
-    data_folder = Path(f"wikitextprocessor/data/{args.lang_code}")
+    data_folder = Path(f"src/wikitextprocessor/data/{args.lang_code}")
     if not data_folder.exists():
         data_folder.mkdir()
     with data_folder.joinpath("namespaces.json").open(


### PR DESCRIPTION
I started to look at the Spanish Wiktionary and noted that the namespaces are not named correctly. Especially the Appendix namespace which seems to hold the best source of language data.

I have added a format commit so that at least the diff of the last commit allows to see which namespace data has changed.