### PR TITLE
Get language names from ICU

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ def __init__(
     self,
     db_path: Optional[Union[str, Path]] = None,
     lang_code="en",
-    languages_by_code: Dict[str, List[str]] = {},
     template_override_funcs: Dict[str, Callable[[Sequence[str]], str]] = {},
 ):
 ```
@@ -161,7 +160,6 @@ the following arguments:
   first phase. If you wish to re-create the database, you should remove
   the old file first.
 * `lang_code` - the language code of the dump file.
-* `languages_by_code` - Languages data.
 * `template_override_funcs` - Python functions for overriding expanded template text.
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "importlib_resources; python_version < '3.10'",
     "lupa @ git+https://github.com/scoder/lupa.git",
     "lxml",
+    "mediawiki_langcodes",
     "psutil",
     "requests",
 ]

--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -199,7 +199,6 @@ class Wtp:
         "LOCAL_NS_NAME_BY_ID",  # Local namespace names dictionary
         "NS_ID_BY_LOCAL_NAME",
         "namespaces",
-        "LANGUAGES_BY_CODE",
         "lang_code",
         # Python functions for overriding template expanded text
         "template_override_funcs",
@@ -209,7 +208,6 @@ class Wtp:
         self,
         db_path: Optional[Union[str, Path]] = None,
         lang_code="en",
-        languages_by_code: Dict[str, List[str]] = {},
         template_override_funcs: Dict[str, Callable[[Sequence[str]], str]] = {},
     ):
         if isinstance(db_path, str):
@@ -235,12 +233,11 @@ class Wtp:
         self.rev_ht: Dict[CookieData, str] = {}
         self.expand_stack: List[str] = []  # XXX: this has a confusing name
         self.parser_stack: List["WikiNode"] = []
-        self.lang_code = lang_code
+        self.lang_code = lang_code  # dump file language code
         self.data_folder = files("wikitextprocessor") / "data" / lang_code
         self.init_namespace_data()
         self.namespaces: Dict[int, Namespace] = {}
         init_namespaces(self)
-        self.LANGUAGES_BY_CODE = languages_by_code
         self.create_db()
         self.template_override_funcs = template_override_funcs
         self.beginning_of_line = False

--- a/tests/test_lua.py
+++ b/tests/test_lua.py
@@ -1,0 +1,16 @@
+import unittest
+
+from wikitextprocessor import Wtp
+from wikitextprocessor.luaexec import fetch_language_name
+
+
+class TestLua(unittest.TestCase):
+    def setUp(self):
+        self.wtp = Wtp()
+
+    def tearDown(self):
+        self.wtp.close_db_conn()
+
+    def test_fetchlanguage(self):
+        self.assertEqual(fetch_language_name("fr", None), "français")
+        self.assertEqual(fetch_language_name("fr", "en"), "French")


### PR DESCRIPTION
`mw.language.fetchLanguageName` and `mw.language.fetchLanguageNames` use the language data extracted from CLDR(https://cldr.unicode.org)

I can't find the ICU API to get language code from language name, but I guess we could use `getAvailable()` to build a dictionary. Then we could use the icu package to replace the language JSON files in the wiktextract package.

pyicu's doc says the `libicu-dev` package is required on Debian: https://gitlab.pyicu.org/main/pyicu#installing-pyicu