### PR TITLE
Revert `?` added to the analyze template table regex pattern

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -838,7 +838,7 @@ class Wtp:
                     (^|\n) \{\|               # start of line {|
                         (    [^\n]            # any except newline
                         |    \n+[^{|]         # any except { or | at line start
-                        |    \n+\|[^}]?       # | + any except } at linestart
+                        |    \n+\|[^}]        # | + any except } at linestart
                         |    \n+\{[^|]        # { + any except | at linestart
                         )*?
                     \n+\s*\|\}                # |}""",


### PR DESCRIPTION
This extra `?` causes catastrophic backtracking in page https://en.wiktionary.org/wiki/Template:sw-conj/table

But the regex still has more backtrack bugs if it can't match a table, we're just lucky the templates are not long enough to halt the command. Many templates are marked need pre-expand is because the table can't be matched.

We should use a simpler approach to count and compare the numbers of `{|` and `|}`.