### PR TITLE
Don't process Template args with `html.unescape()`

### DIFF
--- a/src/wikitextprocessor/luaexec.py
+++ b/src/wikitextprocessor/luaexec.py
@@ -490,7 +490,6 @@ def call_lua_sandbox(
             frame_args = {}
             for k, arg in args.items():
                 arg = re.sub(r"(?si)<\s*noinclude\s*/\s*>", "", arg)
-                arg = html.unescape(arg)
                 frame_args[k] = arg
         else:
             assert isinstance(args, (list, tuple))
@@ -528,7 +527,6 @@ def call_lua_sandbox(
                 # does not always like them (e.g., remove_links() in
                 # Module:links).
                 arg = re.sub(r"(?si)<\s*noinclude\s*/\s*>", "", arg)
-                arg = html.unescape(arg)
                 frame_args[k] = arg
         frame_args_lt: "_LuaTable" = lua.table_from(frame_args)  # type: ignore[union-attr]
 


### PR DESCRIPTION
Fixes Lua errors in English Wiktionary page "oxymoronicness" and "Gendergap".

Lua error message: `[string "Module:languages/error"]:87: The language or  etymology language code "re" is not valid (see [⁠[⁠Wiktionary:List of languages]]): title=re:publica 2014, der 1.`

It seems "Module:quote" splits the argument by ":" and checks if it is language code at line 209.