### PR TITLE
Add NodeKind.LEVEL1 to parser to support parsing the Russian Wiktionary

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -47,7 +47,7 @@ from .common import (
 )
 from .luaexec import call_lua_sandbox
 from .node_expand import NodeHandlerFnCallable, to_html, to_text, to_wikitext
-from .parser import LEVEL_NODES, NodeKind, WikiNode, parse_encoded
+from .parser import KIND_TO_LEVEL, WikiNode, parse_encoded
 from .parserfns import PARSER_FUNCTIONS, call_parser_function, init_namespaces
 from .wikihtml import ALLOWED_HTML_TAGS
 
@@ -390,7 +390,7 @@ class Wtp:
         if self.parser_stack:
             titles: List[str] = []
             for node in self.parser_stack:
-                if node.kind in LEVEL_NODES:
+                if node.kind in KIND_TO_LEVEL:
                     if not node.largs:
                         continue
                     lst = (

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2523,16 +2523,26 @@ def foo(x):
         template_node = tree.children[0]
         self.assertTrue(isinstance(template_node, TemplateNode))
         self.assertEqual(template_node.template_name, "zh-x")
-        self.assertEqual(template_node.template_parameters, {
-            1: "葉落歸根，來 時 無 口。",
-            2: "",
-            3: "CL",
-            "ref": "宋·釋道原《景德傳燈錄》",
-            "collapsed": "y",
-        })
+        self.assertEqual(
+            template_node.template_parameters,
+            {
+                1: "葉落歸根，來 時 無 口。",
+                2: "",
+                3: "CL",
+                "ref": "宋·釋道原《景德傳燈錄》",
+                "collapsed": "y",
+            },
+        )
         self.ctx.add_page("Template:zh-x", 10, "{{{1}}}")
         self.assertEqual(self.ctx.expand(wikitext), "葉落歸根，來 時 無 口。")
 
+    def test_level_1_header(self):
+        tree = self.parse("test", "=Foo=")
+        self.assertEqual(len(tree.children), 1)
+        level_node = tree.children[0]
+        self.assertTrue(isinstance(level_node, LevelNode))
+        self.assertEqual(level_node.largs, [["Foo"]])
+        self.assertEqual(len(level_node.children), 0)
 
 
 # XXX implement <nowiki/> marking for links, templates


### PR DESCRIPTION
In my quest for adding basic support for parsing further Wiktionary editions, I have started to look into the Russian Wiktionary and ran immediately into a problem.

 As per their conventions, a the [page structure](https://ru.wiktionary.org/wiki/Викисловарь:Правила_оформления_статей) of a Russian Wiktionary entry uses h1 headings to start the different language sections.

For example:
```
= {{-en-}} =

== yield I ==

=== Морфологические и синтаксические свойства ===
{{сущ en||||}}

{{морфо|прист1=|корень1=|суфф1=|оконч=|частица=}}

=== Произношение ===
{{transcriptions||}}

=== Семантические свойства ===
```

This pull request is to add support for parsing level 1 headings to WikiNodes with kind == NodeKind.LEVEL1, necessary for correctly extracting the Russian Wiktionary.

---
Comments:

- My changes don't seem to break any of the test suites, so I hope that I have done everything correctly.
- For testing the level 1 headings, I have adapted the tests for level 2 to 6 headings to level 1 headings. There is no some redundancy in testing the interaction between different levels which we might want to remove again. (?)
- I am not too familiar with the parser and there might be some implicit assumptions that Level 1 headings don't exist? Please advise me if anything else needs to be updated.

Many thanks in advance!