### PR TITLE
Add newlines before key chars when expanding

### DIFF
--- a/src/wikitextprocessor/common.py
+++ b/src/wikitextprocessor/common.py
@@ -59,3 +59,11 @@ def nowiki_quote(text: str) -> str:
         return _nowiki_map[m.group(0)]
 
     return re.sub(_nowiki_re, _nowiki_repl, text)
+
+def add_newline_to_expansion(text: str) -> str:
+    """https://meta.wikimedia.org/wiki/Help:Newlines_and_spaces#Automatic_newline
+    When templates (and parserfunctions) are expanded, we should check for
+    these special characters at the start and insert a newline if detected."""
+    if isinstance(text, str) and text.startswith(("*", ";", ":", "#", "{|")):
+        return "\n" + text
+    return text

--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -14,6 +14,7 @@ import tempfile
 import urllib.parse
 from collections import defaultdict, deque
 from collections.abc import Sequence
+from .common import add_newline_to_expansion
 from dataclasses import dataclass
 from functools import lru_cache
 
@@ -1562,6 +1563,7 @@ class Wtp:
                     # to capture or alter the expansion
                     # print("TEMPLATE EXPANDED: {} {} -> {!r}"
                     #       .format(name, ht, t))
+                    t = add_newline_to_expansion(t)
                     if post_template_fn is not None and t:
                         t2 = post_template_fn(urllib.parse.unquote(name), ht, t)
                         if t2 is not None:

--- a/src/wikitextprocessor/parserfns.py
+++ b/src/wikitextprocessor/parserfns.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 import dateparser
 
-from .common import MAGIC_NOWIKI_CHAR, nowiki_quote
+from .common import MAGIC_NOWIKI_CHAR, nowiki_quote, add_newline_to_expansion
 from .wikihtml import ALLOWED_HTML_TAGS
 
 if TYPE_CHECKING:
@@ -1697,4 +1697,6 @@ def call_parser_function(
             sortid="parserfns/1393",
         )
         return ""
-    return fn(ctx, fn_name, args, expander)
+
+    return add_newline_to_expansion(fn(ctx, fn_name, args, expander))
+    # return fn(ctx, fn_name, args, expander)

--- a/tests/test_wikiprocess.py
+++ b/tests/test_wikiprocess.py
@@ -1593,7 +1593,7 @@ MORE
         self.ctx.add_page("Template:t1", 10, "{|\n! Hdr\n{{row|foo}}\n|}")
         self.ctx.start_page("Tt")
         ret = self.ctx.expand("{{t1}}")
-        self.assertEqual(ret, "{|\n! Hdr\n||bar\n| |baz\n| zap\n|}")
+        self.assertEqual(ret, "\n{|\n! Hdr\n||bar\n| |baz\n| zap\n|}")
 
     def test_template25(self):
         # This example is from


### PR DESCRIPTION
https://meta.wikimedia.org/wiki/Help:Newlines_and_spaces#Automatic_newline

Before certain key character, "*", ";", ":", "{|", "#", wikitext expansion (afaict both templates and parserfns) should have an inserted newline '\n' at the start of the string.

This doesn't directly fix the original issue where this was detected, but this small commit should at least shift the code to be more correct.

There may be kludges still left in other parts of the code that emulate this behavior for specific contexts, but those probably rely on heuristically detecting when something is wrong, so they shouldn't by mistriggered easily by this change.

If some code is found that inserts newlines or splits lines before the characters mentioned above, it might be ok to remove that kludge.