### PR TITLE
Remove catastrophic backtracking table regex in `_analyze_template`

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -837,7 +837,16 @@ class Wtp:
         table_end_pos = []
         # `[[wikt:/|}]]` in Template:Mon standard keyboard
         # and `{{l|mul|} }}` in Template:punctuation are not end of table token
-        for m in re.finditer(r"(?<!{){\||\|}(?!\s*}|])", body):
+        # but `|}]]` in Template:Lithuania map is a table
+        for m in re.finditer(
+            r"""
+            (?<!{){\|  # `{|` not after `{`, like `{{{|}}}`
+            |
+            \|}(?!\s*})  # `|}` not before ` }`
+            """,
+            body,
+            re.VERBOSE,
+        ):
             if m.group() == "{|":
                 table_start_pos.append(m.start())
             else:


### PR DESCRIPTION
The original table regex has serious backtracking bug in some pages and it marks 140 false positive templates as having unpaired table.

Before the change the code runs several minutes for the English Wiktionary dump file and hung for the Russian Wikipedia dump file. It now finishes instantly.

Here are the templates marked as having unpaired tables before but not after this change:
<details>
<summary>click to expand</summary>
<code>
[
  "Template:roa-lor-conj-être",
  "Template:no-verb table passive",
  "Template:wa-conj-er-R",
  "Template:roa-fcm-conj-étre",
  "Template:klj-infl-noun/sandbox",
  "Template:liv-noun-pū/forms",
  "Template:frp-old-conj-aveir",
  "Template:mt-conj",
  "Template:sa-conj-pre-58",
  "Template:rgn-conj-first-cons-table",
  "Template:roa-gal-conj-anduirr",
  "Template:klj-infl-noun-comp",
  "Template:nrf-conj-table-rouen",
  "Template:roa-gal-conj-table",
  "Template:pcd-conj-er1",
  "Template:R:lhu",
  "Template:roa-gal-conj-aveir",
  "Template:wa-conj-i-R",
  "Template:fa-conj-head",
  "Template:olo-decl",
  "Template:pcd-conj-er2",
  "Template:roa-gal-conj-conduirr",
  "Template:wa-conj-poleur",
  "Template:grc-ipa-rows-koi",
  "Template:sa-conj-pre-them",
  "Template:frp-conj-fâre",
  "Template:wa-conj-aler",
  "Template:frp-conj-volêr",
  "Template:ett-IPA",
  "Template:roa-gal-conj-acreistr",
  "Template:Classical Japanese pronouns and demonstratives",
  "Template:frp-conj-aouir",
  "Template:roa-gal-conj-viendr",
  "Template:roa-brg-conj-être",
  "Template:he-weakroot",
  "Template:dsb-prep",
  "Template:wa-conj-ner",
  "Template:frp-conj-savêr",
  "Template:shogi diagram",
  "Template:roa-gal-conj-aduirr",
  "Template:wa-conj-er-R-eye",
  "Template:roa-gal-conj-creirr",
  "Template:roa-gal-conj-terouer",
  "Template:ang-decl-se",
  "Template:wa-conj-e",
  "Template:roa-gal-conj-valeir",
  "Template:frp-conj-fondre",
  "Template:mh-c1",
  "Template:pcd-conj-table",
  "Template:sa-verb-opt",
  "Template:wa-conj-voleur",
  "Template:xpu-ipa-rows",
  "Template:roa-gal-conj-creistr",
  "Template:nrf-conj-table-cot",
  "Template:cel-gau-decl-o-m",
  "Template:mh-c2",
  "Template:wa-conj-er",
  "Template:coefficient/pt",
  "Template:roa-cha-conj-être",
  "Template:poz-mly-pro-personal pronouns",
  "Template:pro-decl-ppron",
  "Template:cop-IPA",
  "Template:ja-phrase/sandbox",
  "Template:roa-brg-conj-être-m",
  "Template:wa-conj-pårler",
  "Template:cel-gau-decl-r",
  "Template:roa-gal-conj-dirr",
  "Template:cel-gau-decl-a",
  "Template:grc-ipa-rows",
  "Template:rgn-conj-first-vow-table",
  "Template:roa-gal-conj-chaeir",
  "Template:wa-conj-fé",
  "Template:frp-conj-crêtre",
  "Template:roa-gal-conj-beirr",
  "Template:pcd-conj-er",
  "Template:roa-gal-conj-acreirr",
  "Template:klj-infl-noun",
  "Template:nrf-conj-répounre",
  "Template:timeline:generations",
  "Template:nrf-conj-prenre",
  "Template:klj-infl-noun-comp/sandbox",
  "Template:wa-conj-i",
  "Template:roa-brg-conj-voi1",
  "Template:roa-gal-conj-duirr",
  "Template:cel-gau-decl-gre-r",
  "Template:sa-conj-perf",
  "Template:roa-gal-conj-alaer",
  "Template:frp-conj-rèpondre",
  "Template:roa-gal-conj-veir",
  "Template:User cs",
  "Template:el-Greek-verb-header",
  "Template:cel-gau-decl-ita-o-m",
  "Template:roa-brg-conj-voi",
  "Template:redcol5",
  "Template:ro-conj",
  "Template:roa-brg-conj-venir",
  "Template:grc-ipa-rows-byz",
  "Template:sa-verb-pres",
  "Template:cel-gau-decl-o-n",
  "Template:rgn-conj-third-cons-table",
  "Template:nrf-conj-ête-brayon",
  "Template:frp-conj-mouedre",
  "Template:rgn-conj-third-vow-table",
  "Template:User:Victar/der3",
  "Template:pcd-conj-ier",
  "Template:rgn-IPA",
  "Template:User cs-u-sd-cz642",
  "Template:English possessive pronouns",
  "Template:nrf-conj-ête-rouen",
  "Template:tl-conj-table",
  "Template:pox-prep",
  "Template:wa-conj-diveur",
  "Template:wa-conj-er-K",
  "Template:roa-bbn-conj-être",
  "Template:sv-nogomatch",
  "Template:avd-categoryTOC",
  "Template:wa-conj-lére",
  "Template:User it",
  "Template:roa-gal-conj-descreistr",
  "Template:ast-conj-table",
  "Template:nrf-conj-aveir",
  "Template:roa-gal-conj-faere",
  "Template:dlm-conj-contribuer",
  "Template:wa-conj-er-T",
  "Template:mh-c",
  "Template:cel-gau-decl-ita-a",
  "Template:roa-gal-conj-desduirr",
  "Template:cel-bry-conj-table",
  "Template:dlm-conj-dormer",
  "Template:roa-gal-conj-voulair",
  "Template:frp-conj-dére",
  "Template:fi-conj-ei",
  "Template:ko new/ipa/ca",
  "Template:roa-gal-conj-descreirr",
  "Template:ang-decl-hwa",
  "Template:fa-conj-colloq-head",
  "Template:roa-gal-conj-concreirr",
  "Template:frp-old-conj-estre",
  "Template:frp-conj-chalêr",
  "Template:ar-nogomatch"
]
</code>
</details>

I only checked some of them, and all the templates that I checked doesn't contain unpaired table. And the new code finds a template that does have unpaired table but was missed before:  [Template:nv-stem-set-header](https://en.wiktionary.org/wiki/Template:nv-stem-set-header)