### PR TITLE
Clear the timeout hook after a Lua model is finished execution

### DIFF
--- a/src/wikitextprocessor/lua/_sandbox_phase1.lua
+++ b/src/wikitextprocessor/lua/_sandbox_phase1.lua
@@ -174,11 +174,19 @@ local function _lua_set_timeout(timeout)
         _lua_current_max_time = _lua_max_time
     end
     local start_time = os.time()
-    debug.sethook(function()
-        if os.time() > start_time + _lua_current_max_time then
-            error("Lua timeout error")
-        end
-    end, "", 100000)
+    debug.sethook(
+        function()
+            if os.time() > start_time + _lua_current_max_time then
+                error("Lua timeout error")
+            end
+        end,
+        "",
+        100000
+    )
+end
+
+local function _lua_clear_timeout_hook()
+    debug.sethook()
 end
 
 -- Wiktionary uses a Module named "debug".  Force it to be loaded by
@@ -417,6 +425,7 @@ local function _lua_reset_env()
     env["xpcall"] = _orig_xpcall
     env["_lua_set_python_loader"] = _lua_set_python_loader
     env["_lua_set_timeout"] = _lua_set_timeout
+    env["_lua_clear_timeout_hook"] = _lua_clear_timeout_hook
     env["_lua_io_flush"] = _lua_io_flush
     env["_lua_reset_env"] = _lua_reset_env
     env["_orig_format"] = _orig_format

--- a/src/wikitextprocessor/lua/_sandbox_phase2.lua
+++ b/src/wikitextprocessor/lua/_sandbox_phase2.lua
@@ -188,6 +188,7 @@ local function _lua_invoke(mod_name, fn_name, frame, page_title, timeout)
     end
     -- Call the function in the module
     local st, v = pcall(fn, frame)
+    _lua_clear_timeout_hook()
     -- print("Lua sandbox:", tostring(v))
     if type(v) == "string" then
         return st, v


### PR DESCRIPTION
I got a strange Lua timeout error from the 20231201 Chinese Wiktionary dump file on page "还了得", a simple page. The Lua error is at the `_lua_reset_env()`, before running the Lua module code.