### PR TITLE
Return Lua `loadstring()` error message

### DIFF
--- a/src/wikitextprocessor/lua/_sandbox_phase1.lua
+++ b/src/wikitextprocessor/lua/_sandbox_phase1.lua
@@ -77,6 +77,9 @@ function new_loader(modname, mod_env)
     else
         fn, msg = load(content, modname)
     end
+    if fn == nil then
+        return nil, "load '" .. modname .. "' failed: " .. msg
+    end
     setfenv(fn, mod_env)
     -- Cache the loaded module initialization function
     loader_cache[modname] = fn


### PR DESCRIPTION
An unreproducible Lua error on kaikki.org in page "बुझ्नु": `lupa.lua51.LuaError: [string "<python>"]:80: bad argument 1 to 'setfenv' (number expected, got nil)`

But the Lua function error message is not in the log.