### PR TITLE
Pass namespace id to `Wtp.get_page()` as much as possible

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -1445,7 +1445,9 @@ class Wtp:
                     name = tname
 
                     # Check for undefined templates
-                    if not self.template_exists(name):
+                    if not self.page_exists(
+                        name, self.NAMESPACE_DATA["Template"]["id"]
+                    ):
                         # XXX tons of these in enwiktionary-20201201 ???
                         # self.debug("undefined template {!r}.format(tname),
                         #           sortid="core/1171")
@@ -1754,8 +1756,8 @@ class Wtp:
             ) from e
         return None
 
-    def page_exists(self, title: str) -> bool:
-        return self.get_page(title) is not None
+    def page_exists(self, title: str, namespace_id: Optional[int] = 0) -> bool:
+        return self.get_page(title, namespace_id) is not None
 
     def get_all_pages(
         self,
@@ -1787,12 +1789,6 @@ class Wtp:
                 model=result[5],
             )
 
-    def template_exists(self, name: str) -> bool:
-        return (
-            self.get_page(name, self.NAMESPACE_DATA["Template"]["id"])
-            is not None
-        )
-
     def check_template_need_expand(
         self,
         name: str,
@@ -1814,16 +1810,8 @@ class Wtp:
 
         return page.need_pre_expand
 
-    def read_by_title(
-        self, title: str, namespace_id: Optional[int] = None
-    ) -> Optional[str]:
-        """Reads the contents of the page.  Returns None if the page does
-        not exist."""
-        page = self.get_page_resolve_redirect(title, namespace_id)
-        return page.body if page is not None else None
-
     def get_page_resolve_redirect(
-        self, title: str, namespace_id: Optional[int] = None
+        self, title: str, namespace_id: int
     ) -> Optional[Page]:
         page = self.get_page(title, namespace_id)
         if page is None:
@@ -1831,6 +1819,10 @@ class Wtp:
         if page.redirect_to is not None:
             return self.get_page(page.redirect_to, namespace_id, True)
         return page
+
+    def get_page_body(self, title: str, namespace_id: int) -> Optional[str]:
+        page = self.get_page_resolve_redirect(title, namespace_id)
+        return None if page is None else page.body
 
     def parse(
         self,

--- a/src/wikitextprocessor/lua/mw_title.lua
+++ b/src/wikitextprocessor/lua/mw_title.lua
@@ -118,7 +118,7 @@ function mw_title_meta:canonicalUrl(query)
 end
 
 function mw_title_meta:getContent()
-    return mw_python_get_page_content(self.fullText)
+    return mw_python_get_page_content(self.fullText, self.namespace)
 end
 
 local mw_title = {

--- a/src/wikitextprocessor/luaexec.py
+++ b/src/wikitextprocessor/luaexec.py
@@ -79,7 +79,7 @@ def lua_loader(ctx: "Wtp", modname: str) -> Optional[str]:
             # that the sandbox always gets loaded from a local file.
             data = None
         else:
-            data = ctx.read_by_title(modname, ns_data["id"])
+            data = ctx.get_page_body(modname, ns_data["id"])
     else:
         # Try to load it from a file
         path = modname
@@ -225,7 +225,7 @@ def get_page_info(ctx: "Wtp", title: str, namespace_id: int) -> "_LuaTable":
     assert ctx.lua is not None
 
     page_id = 0  # XXX collect required info in phase 1
-    page: Optional["Page"] = ctx.get_page(title, namespace_id)
+    page = ctx.get_page(title, namespace_id)
     # whether the page exists and what its id might be
     dt = {
         "id": page_id,
@@ -233,16 +233,6 @@ def get_page_info(ctx: "Wtp", title: str, namespace_id: int) -> "_LuaTable":
         "redirectTo": page.redirect_to if page is not None else None,
     }
     return ctx.lua.table_from(dt)
-
-
-def get_page_content(ctx: "Wtp", title: str) -> Optional[str]:
-    """Retrieves the full content of the page identified by the title.
-    Currently this will only return content for the current page.
-    This returns None if the page is other than the current page, and
-    False if the page does not exist (currently not implemented)."""
-
-    # Read the page by its title
-    return ctx.read_by_title(title.strip())
 
 
 def fetch_language_name(code: str, inLanguage: Optional[str]) -> str:
@@ -295,7 +285,9 @@ def call_set_functions(
             )
         return get_page_info(ctx, title, ns_id)
 
-    def debug_get_page_content(x: str, *bad_args: Any) -> Optional[str]:
+    def debug_get_page_content(
+        title: str, namespace_id: int, *bad_args: Any
+    ) -> Optional[str]:
         if bad_args:
             print(
                 f"MAKE_FRAME GET_PAGE_CONTENT DEBUG:"
@@ -303,7 +295,7 @@ def call_set_functions(
                 f" {ctx.title=},"
                 f" {multiprocessing.current_process().name}"
             )
-        return get_page_content(ctx, x)
+        return ctx.get_page_body(title, namespace_id)
 
     def debug_fetch_language_name(
         code: str, inLanguage: str, *bad_args: Any

--- a/src/wikitextprocessor/parserfns.py
+++ b/src/wikitextprocessor/parserfns.py
@@ -153,7 +153,7 @@ def lst_fn(
     """Implements the #lst (alias #section etc) parser function."""
     pagetitle = expander(args[0]).strip() if args else ""
     chapter = expander(args[1]).strip() if len(args) >= 2 else ""
-    text: Optional[str] = ctx.read_by_title(pagetitle)
+    text = ctx.get_page_body(pagetitle, 0)
     if text is None:
         ctx.warning(
             "{} trying to transclude chapter {!r} from non-existent "


### PR DESCRIPTION
I suspect this function could return wrong result from cache when namespace id is not passed