### PR TITLE
Detect header tokens before italics/bold

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2545,6 +2545,13 @@ def foo(x):
         self.assertEqual(len(level_node.children), 0)
 
 
+    def test_hdr_italics(self):
+        tree = self.parse("test", "=== ''nachklassisch'' ===")
+        self.assertEqual(len(tree.children), 1)
+        self.assertEqual(tree.children[0].kind, NodeKind.LEVEL3)
+        self.assertEqual(len(tree.children[0].largs), 1)
+        self.assertEqual(tree.children[0].largs[0][0].kind, NodeKind.ITALIC)
+
 # XXX implement <nowiki/> marking for links, templates
 #  - https://en.wikipedia.org/wiki/Help:Wikitext#Nowiki
 #  - fix test_nowiki11 and continue


### PR DESCRIPTION
Due to an oversight (because it didn't happen on
en.wiktionary.org), italics or bold inside a header broke the header token detection, because
headers were detected as part of a tokenizing regex that was run on a partitioned line if there were any italics or bold tokens present.

To fix this, just detect headers before-hand; even previously, headers were handled by recursively
tokenizing their contents, so this was pretty much just copy-pasting stuff around, thankfully.

Test written originally by @empiriker
Co-authored-by: empiriker