### PR TITLE
Remove code added from commit 6d2d466b2a640961c68cb93db6330f40cdf8a588

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -1284,25 +1284,6 @@ class Wtp:
                             k = re.sub(r"\s+", " ", k).strip()
                         v = argmap.get(k, None)
                         if v is not None:
-                            # This kludge is to stop intrusive "="s from
-                            # being parsed as parameter assignment operators
-                            # (quadratic/English, {{trans-top|1=...y = ax²...}}
-                            # when an argument is passed on somewhere else;
-                            # {{#invoke...|{{{1}}}}} ->
-                            # {{#invoke...|...y = ax²...}}, "y"-key: "ax²..."
-                            # If an equal sign inside a argument, but outside
-                            #  {{}} template braces or <> html brackets
-                            # is encountered, escape it  as the equal-sign
-                            # HTML entity.
-                            if "=" in v:
-                                nv = ""
-                                em = re.split(r"({{.+?}}|<.+?>)", v)
-                                for s in em:
-                                    if re.match(r"({{.*}}|<.*>)$", s):
-                                        nv += s
-                                    else:
-                                        nv += s.replace("=", "&#61;")
-                                v = nv
                             parts.append(v)
                             continue
                         if len(args) >= 2:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2544,6 +2544,44 @@ def foo(x):
         self.assertEqual(level_node.largs, [["Foo"]])
         self.assertEqual(len(level_node.children), 0)
 
+    def test_equal_sign_in_template_argument(self):
+        # remove a strange code replaces `=` in argument with `&#61;`
+        # https://en.wiktionary.org/wiki/quadratic
+        self.ctx.add_page(
+            "Template:trans-top", 10, "{{#invoke:translations|top}}"
+        )
+        self.ctx.add_page(
+            "Module:translations",
+            828,
+            """
+        local export = {}
+        function export.top(frame)
+          local args = frame:getParent().args
+          return args[1]
+        end
+
+        return export
+        """,
+        )
+        self.ctx.start_page("")
+        wikitext = "{{trans-top|1=of a class of polynomial of the form y = ax² + bx + c}}"
+        expanded = self.ctx.expand(wikitext)
+        self.assertEqual(
+            expanded, "of a class of polynomial of the form y = ax² + bx + c"
+        )
+
+        # https://en.wiktionary.org/wiki/can
+        self.ctx.add_page("Template:qualifier", 10, "({{{1|}}})")
+        self.ctx.add_page(
+            "Template:tt+", 10, "⦃⦃t+¦{{{1|}}}¦{{{2|}}}¦tr={{{tr|}}}⦄⦄"
+        )
+        wikitext = "{{qualifier|the ability/inability to achieve a result is expressed with various verb complements, e.g. {{tt+|cmn|得了|tr=-deliǎo}}}}"
+        expanded = self.ctx.expand(wikitext)
+        self.assertEqual(
+            expanded,
+            "(the ability/inability to achieve a result is expressed with various verb complements, e.g. ⦃⦃t+¦cmn¦得了¦tr=-deliǎo⦄⦄)",
+        )
+
 
 # XXX implement <nowiki/> marking for links, templates
 #  - https://en.wikipedia.org/wiki/Help:Wikitext#Nowiki


### PR DESCRIPTION
I'm not sure what error that commit was trying to fix, the current code has no problem process the translation section of the "quadratic" page and the "trans-top" template's body is `{{#invoke:translations|top}}`. Even if a template parameter is passed to `#invoke` and it contains `=` the code is still correct and don't need to replace `=`.

Remove this code fixes the Lua error in page "can" because `=` is replaced to `&#61;` and causes a error in module "translations/multi".