### PR TITLE
Ignore patch updates of the "typos" command

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "typos"  # ignore patch updates
+        update-types: ["version-update:semver-patch"]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -24,4 +24,4 @@ jobs:
       # - run: python -m black --check .
       # - run: python -m mypy -p wikitextprocessor
       # - run: python -m ruff .
-      - uses: crate-ci/typos@v1.16.23
+      - uses: crate-ci/typos@v1.16.24

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'


### PR DESCRIPTION
"typos" doesn't have a stable tag("v1") like other actions and it updates quite frequently. Also update some action dependencies.