### PR TITLE
Implement `PAGELANGUAGE` and `#language` magic words

### DIFF
--- a/src/wikitextprocessor/parserfns.py
+++ b/src/wikitextprocessor/parserfns.py
@@ -1485,6 +1485,21 @@ def statements_fn(
     return _query_wikidata_statement(prop, wikidata_item, ctx.lang_code)
 
 
+def pagelanguage_fn(
+    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+) -> str:
+    return ctx.lang_code
+
+
+def language_fn(
+    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+) -> str:
+    if len(args) > 0:
+        from mediawiki_langcodes import code_to_name
+
+        return code_to_name(args[0], ctx.lang_code)
+    return ""
+
 # This list should include names of predefined parser functions and
 # predefined variables (some of which can take arguments using the same
 # syntax as parser functions and we treat them as parser functions).
@@ -1571,6 +1586,7 @@ PARSER_FUNCTIONS = {
     "DISPLAYTITLE": displaytitle_fn,
     "displaytitle": displaytitle_fn,
     "DEFAULTSORT": defaultsort_fn,
+    "PAGELANGUAGE": pagelanguage_fn,
     "lc": lc_fn,
     "lcfirst": lcfirst_fn,
     "uc": uc_fn,
@@ -1635,6 +1651,7 @@ PARSER_FUNCTIONS = {
     "#Abschnitt-x": unimplemented_fn,
     "#trecho-x": unimplemented_fn,
     "#section-x": unimplemented_fn,
+    "#language": language_fn,
 }
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2582,13 +2582,20 @@ def foo(x):
             "(the ability/inability to achieve a result is expressed with various verb complements, e.g. ⦃⦃t+¦cmn¦得了¦tr=-deliǎo⦄⦄)",
         )
 
-
     def test_hdr_italics(self):
         tree = self.parse("test", "=== ''nachklassisch'' ===")
         self.assertEqual(len(tree.children), 1)
         self.assertEqual(tree.children[0].kind, NodeKind.LEVEL3)
         self.assertEqual(len(tree.children[0].largs), 1)
         self.assertEqual(tree.children[0].largs[0][0].kind, NodeKind.ITALIC)
+
+    def test_language_parser_function(self):
+        self.ctx.start_page("")
+        self.assertEqual(self.ctx.expand("{{PAGELANGUAGE}}"), "en")
+        self.assertEqual(
+            self.ctx.expand("{{#language:{{PAGELANGUAGE}}}}"), "English"
+        )
+
 
 # XXX implement <nowiki/> marking for links, templates
 #  - https://en.wikipedia.org/wiki/Help:Wikitext#Nowiki


### PR DESCRIPTION
Used in page "Star Trek" and "Coriandrum sativum" but not required for extracted JSON file.