### PR TITLE
Save interwiki maps data to SQLite db file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,5 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
-      - dependency-name: "typos"  # ignore patch updates
+      - dependency-name: "crate-ci/typos"  # ignore patch updates
         update-types: ["version-update:semver-patch"]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,4 +24,4 @@ jobs:
       # - run: python -m black --check .
       # - run: python -m mypy -p wikitextprocessor
       # - run: python -m ruff .
-      - uses: crate-ci/typos@v1.16.24
+      - uses: crate-ci/typos@v1.16.25

--- a/src/wikitextprocessor/interwiki.py
+++ b/src/wikitextprocessor/interwiki.py
@@ -1,11 +1,14 @@
-from functools import cache
+from typing import TYPE_CHECKING, Union
+
+if TYPE_CHECKING:
+    from .core import Wtp
 
 
-def get_interwiki_data():
+def get_interwiki_data(wtp: "Wtp") -> list[dict[str, Union[str, bool]]]:
     import requests
 
     r = requests.get(
-        "https://www.mediawiki.org/w/api.php",
+        f"https://{wtp.lang_code}.{wtp.project}.org/w/api.php",
         params={
             "action": "query",
             "meta": "siteinfo",
@@ -21,43 +24,54 @@ def get_interwiki_data():
     return []
 
 
-@cache
-def get_interwiki_map(lang_code, project):
-    # https://www.mediawiki.org/wiki/Manual:Interwiki
-    # https://www.mediawiki.org/wiki/Extension:Scribunto/Lua_reference_manual#mw.site.interwikiMap
-    interwiki_map = {}
-    for result in get_interwiki_data():
-        new_map = {
-            "prefix": result["prefix"],
-            "url": result["url"],
-            "isProtocolRelative": result.get("protorel", False),
-            "isLocal": result.get("local", False),
-            "isCurrentWiki": False,
+def init_interwiki_map(wtp: "Wtp") -> None:
+    wtp.db_conn.execute(
+        """
+    CREATE TABLE IF NOT EXISTS interwiki_maps (
+    prefix TEXT PRIMARY KEY,
+    url TEXT,
+    protorel INTEGER,
+    local INTEGER)
+    """
+    )
+    if len(get_interwiki_map(wtp)) == 0:
+        for result in get_interwiki_data(wtp):
+            wtp.db_conn.execute(
+                "INSERT INTO interwiki_maps VALUES(?, ?, ?, ?)",
+                (
+                    result["prefix"],
+                    result["url"],
+                    result.get("protorel", False),
+                    result.get("local", False),
+                ),
+            )
+        wtp.db_conn.commit()
+
+
+def get_interwiki_map(wtp: "Wtp") -> dict[str, dict[str, Union[str, bool]]]:
+    return {
+        prefix: {
+            "prefix": prefix,
+            "url": url if not protorel else url.removeprefix("https:"),
+            "isProtocolRelative": bool(protorel),
+            "isLocal": bool(local),
+            "isCurrentWiki": url.startswith(
+                f"https://{wtp.lang_code}.{wtp.project}.org"
+            ),
             "isTranscludable": False,
             "isExtraLanguageLink": False,
         }
-        if lang_code != "en":
-            if new_map["url"].startswith(f"https://en.{project}.org"):
-                new_map["isCurrentWiki"] = True
-                new_map[
-                    "url"
-                ] = f"https://{lang_code}.{project}.org/wiki/$1"
-            elif new_map["url"].startswith("https://en."):
-                new_map[
-                    "url"
-                ] = f"https://{lang_code}.{new_map['url'][11:]}"
-        if new_map["isProtocolRelative"]:
-            new_map["url"] = new_map["url"].removeprefix("https:")
-        interwiki_map[result["prefix"]] = new_map
-
-    return interwiki_map
+        for (prefix, url, protorel, local) in wtp.db_conn.execute(
+            "SELECT * FROM interwiki_maps"
+        )
+    }
 
 
 def mw_site_interwikiMap(wtp, filter_arg=None):
     # https://www.mediawiki.org/wiki/Manual:Interwiki
     # https://www.mediawiki.org/wiki/Extension:Scribunto/Lua_reference_manual#mw.site.interwikiMap
     interwiki_map = {}
-    for key, value in get_interwiki_map(wtp.lang_code, wtp.project).items():
+    for key, value in get_interwiki_map(wtp).items():
         if (
             filter_arg is None
             or (filter_arg == "local" and value["isLocal"])

--- a/src/wikitextprocessor/parserfns.py
+++ b/src/wikitextprocessor/parserfns.py
@@ -1623,7 +1623,6 @@ PARSER_FUNCTIONS = {
     "#categorytree": (categorytree_fn, True),  # This takes kwargs
     "#coordinates": unimplemented_fn,
     "#invoke": unimplemented_fn,
-    "#language": unimplemented_fn,
     "#lst": lst_fn,
     "#lsth": unimplemented_fn,
     "#lstx": unimplemented_fn,


### PR DESCRIPTION
Call the `siteinfo` MediaWiki API only once and share the data across worker processes.