### PR TITLE
Type checking 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ wikitextprocessor = [
 
 [tool.mypy]
 mypy_path = "typestubs"
+python_version = 3.9
 
 [tool.coverage.run]
 branch = true

--- a/src/wikitextprocessor/common.py
+++ b/src/wikitextprocessor/common.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2020-2022 Tatu Ylonen.  See file LICENSE and https://ylonen.org
 
 import re
-from typing import Iterator, Dict
+from typing import Iterator
 
 
 # Character range used for marking magic sequences.  This package
@@ -30,7 +30,7 @@ MAGIC_LAST: int = 0x0010fff0
 MAX_MAGICS = MAGIC_LAST - MAGIC_FIRST + 1
 
 # Mappings performed for text inside <nowiki>...</nowiki>
-_nowiki_map: Dict[str, str] = {
+_nowiki_map: dict[str, str] = {
     # ";": "&semi;",
     # "&": "&amp;",
     "=": "&equals;",

--- a/src/wikitextprocessor/dumpparser.py
+++ b/src/wikitextprocessor/dumpparser.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 import unicodedata
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Set
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from .core import Wtp
@@ -33,7 +33,7 @@ def decompress_dump_file(dump_path: str) -> subprocess.Popen:
         raise ValueError("Dump file extension is not .bz2")
 
 
-def parse_dump_xml(ctx: "Wtp", dump_path: str, namespace_ids: Set[int]) -> None:
+def parse_dump_xml(ctx: "Wtp", dump_path: str, namespace_ids: set[int]) -> None:
     from lxml import etree
 
     with decompress_dump_file(dump_path) as p:
@@ -88,8 +88,8 @@ def parse_dump_xml(ctx: "Wtp", dump_path: str, namespace_ids: Set[int]) -> None:
 def process_dump(
     ctx: "Wtp",
     path: str,
-    namespace_ids: Set[int],
-    overwrite_folders: Optional[List[Path]] = None,
+    namespace_ids: set[int],
+    overwrite_folders: Optional[list[Path]] = None,
     skip_extract_dump: bool = False,
     save_pages_path: Optional[Path] = None,
     skip_analyze_templates: bool = False,
@@ -137,7 +137,7 @@ def process_dump(
 
 def analyze_and_overwrite_pages(
     ctx: "Wtp",
-    overwrite_folders: Optional[List[Path]],
+    overwrite_folders: Optional[list[Path]],
     skip_extract_dump: bool,
     skip_analyze_templates: bool,
 ) -> None:
@@ -162,7 +162,7 @@ def analyze_and_overwrite_pages(
 
 
 def overwrite_pages(
-    ctx: "Wtp", folder_paths: List[Path], do_overwrite: bool
+    ctx: "Wtp", folder_paths: list[Path], do_overwrite: bool
 ) -> bool:
     """
     Read text from passed paths and overwrite the correspond pages in database.
@@ -277,7 +277,7 @@ def path_is_on_windows_partition(path: Path) -> bool:
     )
 
 
-def get_windows_invalid_chars() -> Set[str]:
+def get_windows_invalid_chars() -> set[str]:
     return set(map(chr, range(0x00, 0x20))) | set(
         ["/", "\\", ":", "*", "?", '"', "<", ">", "|"]
     )

--- a/src/wikitextprocessor/dumpparser.py
+++ b/src/wikitextprocessor/dumpparser.py
@@ -41,7 +41,7 @@ def parse_dump_xml(ctx: "Wtp", dump_path: str, namespace_ids: Set[int]) -> None:
         namespaces = {None: namespace_str}
         page_nums = 0
         for _, page_element in etree.iterparse(
-            p.stdout, tag=f"{{{namespace_str}}}page"
+            p.stdout, tag=f"{{{namespace_str}}}page" # type: ignore[arg-type]
         ):
             title = page_element.findtext("title", "", namespaces)
             namespace_id = int(page_element.findtext("ns", "0", namespaces))
@@ -115,6 +115,7 @@ def process_dump(
 
     # Add default templates
     template_ns = ctx.NAMESPACE_DATA.get("Template")
+    assert template_ns is not None
     template_ns_id = template_ns["id"]
     template_ns_local_name = template_ns["name"]
     ctx.add_page(  # magic word

--- a/src/wikitextprocessor/luaexec.py
+++ b/src/wikitextprocessor/luaexec.py
@@ -25,12 +25,9 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Dict,
     ItemsView,
     Iterable,
-    List,
     Optional,
-    Tuple,
     Union,
 )
 
@@ -46,7 +43,7 @@ if TYPE_CHECKING:
     from .core import NamespaceDataEntry, Page, ParentData, Wtp
 
 # List of search paths for Lua libraries
-BUILTIN_LUA_SEARCH_PATHS: List[Tuple[str, List[str]]] = [
+BUILTIN_LUA_SEARCH_PATHS: list[tuple[str, list[str]]] = [
     # [path, ignore_modules]
     (".", ["string", "debug"]),
     ("mediawiki-extensions-Scribunto/includes/Engines/LuaCommon/lualib", []),
@@ -111,7 +108,7 @@ def mw_text_decode(text: str, decodeNamedEntities: bool) -> str:
         return html.unescape(text)
 
     # Otherwise decode only selected entities
-    parts: List[str] = []
+    parts: list[str] = []
     pos = 0
     for m in re.finditer(r"&(lt|gt|amp|quot|nbsp);", text):
         if pos < m.start():
@@ -136,7 +133,7 @@ def mw_text_decode(text: str, decodeNamedEntities: bool) -> str:
 
 def mw_text_encode(text: str, charset: str) -> str:
     """Implements the mw.text.encode function for Lua code."""
-    parts: List[str] = []
+    parts: list[str] = []
     for ch in str(text):
         if ch in charset:
             chn = ord(ch)
@@ -149,14 +146,14 @@ def mw_text_encode(text: str, charset: str) -> str:
     return "".join(parts)
 
 
-def mw_text_jsondecode(ctx: "Wtp", s: str, *rest: int) -> Dict[Any, Any]:
+def mw_text_jsondecode(ctx: "Wtp", s: str, *rest: int) -> dict[Any, Any]:
     flags = int(rest[0]) if rest else 0
-    value: Dict = json.loads(s)
+    value: dict = json.loads(s)
     assert isinstance(ctx.lua, lupa.LuaRuntime)
     # Assign locally to assure type-checker this exists
     table_from = ctx.lua.table_from
 
-    def recurse(x: Union[List, Tuple, Dict]) -> Any:
+    def recurse(x: Union[list, tuple, dict]) -> Any:
         if isinstance(x, (list, tuple)):
             return table_from(list(map(recurse, x)))
         if not isinstance(x, dict):
@@ -267,7 +264,7 @@ def call_set_functions(
     ctx: "Wtp", set_functions: Callable[["_LuaTable"], None]
 ) -> None:
     assert ctx.lua is not None
-    def debug_mw_text_jsondecode(x: str, *rest: int) -> Dict[Any, Any]:
+    def debug_mw_text_jsondecode(x: str, *rest: int) -> dict[Any, Any]:
         return mw_text_jsondecode(ctx, x, *rest)
 
     def debug_get_page_info(title: str, ns_id: int, *bad_args) -> "_LuaTable":
@@ -470,9 +467,9 @@ def call_lua_sandbox(
     modfn = expander(invoke_args[1]).strip()
 
     def make_frame(
-        pframe: Union[None, Dict, "_LuaTable"],
+        pframe: Union[None, dict, "_LuaTable"],
         title: str,
-        args: Union[Dict[Union[str, int], str], Tuple, List],
+        args: Union[dict[Union[str, int], str], tuple, list],
     ) -> "_LuaTable":
         assert isinstance(title, str)
         assert isinstance(args, (list, tuple, dict))
@@ -534,7 +531,7 @@ def call_lua_sandbox(
             if not isinstance(dt, (str, int, float, type(None))):
                 name: str = str(dt["name"] or "")
                 content: str = str(dt["content"] or "")
-                attrs: Union[Dict[Union[int, str], str], str, "_LuaTable"] = (
+                attrs: Union[dict[Union[int, str], str], str, "_LuaTable"] = (
                     dt["args"] or {}
                 )
             elif len(args) == 1:
@@ -582,11 +579,11 @@ def call_lua_sandbox(
                     "lua callParserFunction missing name", sortid="luaexec/506"
                 )
                 return ""
-            name_or_table: Union[str, "_LuaTable", Dict] = args[0]
-            new_args: Union[Dict, List]
+            name_or_table: Union[str, "_LuaTable", dict] = args[0]
+            new_args: Union[dict, list]
             if not isinstance(name_or_table, str):
                 # name is _LuaTable
-                new_args1: Union["_LuaTable", Dict, str] = name_or_table["args"]
+                new_args1: Union["_LuaTable", dict, str] = name_or_table["args"]
                 if isinstance(new_args1, str):
                     new_args = {1: new_args1}
                 else:
@@ -654,7 +651,7 @@ def call_lua_sandbox(
                 )
                 return ""
             if TYPE_CHECKING:
-                assert isinstance(dt, (_LuaTable, Dict))
+                assert isinstance(dt, (_LuaTable, dict))
             title = dt["title"] or ""
             args2 = dt["args"] or {}
             new_args = [title]
@@ -709,7 +706,7 @@ def call_lua_sandbox(
             return title
 
         # Create frame object as dictionary with default value None
-        frame: Dict[str, Union["_LuaTable", Callable]] = {}
+        frame: dict[str, Union["_LuaTable", Callable]] = {}
         frame["args"] = frame_args_lt
         frame["callParserFunction"] = callParserFunction
         frame["extensionTag"] = extensionTag
@@ -725,7 +722,7 @@ def call_lua_sandbox(
     # (for module being called)
     if parent is not None:
         parent_title: str
-        page_args: Union["_LuaTable", Dict]
+        page_args: Union["_LuaTable", dict]
         parent_title, page_args = parent
         expanded_key_args = {}
         for k, v in page_args.items():
@@ -746,7 +743,7 @@ def call_lua_sandbox(
     lua_exception: Optional[Exception] = None
     try:
         ctx.lua_frame_stack.append(frame)
-        ret: Tuple[bool, str] = ctx.lua_invoke(
+        ret: tuple[bool, str] = ctx.lua_invoke(
             modname, modfn, frame, ctx.title, timeout
         )
         # Lua functions returning multiple values will return a tuple

--- a/src/wikitextprocessor/luaexec.py
+++ b/src/wikitextprocessor/luaexec.py
@@ -780,7 +780,11 @@ def call_lua_sandbox(
         text = unicodedata.normalize("NFC", text)
         return text
     if lua_exception is not None:
-        text = "".join(traceback.format_exception(lua_exception)).strip()
+        text = "".join(traceback.format_exception(
+                            type(lua_exception),
+                            lua_exception,
+                            lua_exception.__traceback__)
+                        ).strip()
     elif not isinstance(text, str):
         text = str(text)
     msg = re.sub(r".*?:\d+: ", "", text.split("\n", 1)[0])

--- a/src/wikitextprocessor/luaexec.py
+++ b/src/wikitextprocessor/luaexec.py
@@ -266,6 +266,7 @@ def fetch_language_names(
 def call_set_functions(
     ctx: "Wtp", set_functions: Callable[["_LuaTable"], None]
 ) -> None:
+    assert ctx.lua is not None
     def debug_mw_text_jsondecode(x: str, *rest: int) -> Dict[Any, Any]:
         return mw_text_jsondecode(ctx, x, *rest)
 

--- a/src/wikitextprocessor/node_expand.py
+++ b/src/wikitextprocessor/node_expand.py
@@ -6,10 +6,7 @@ import re
 import urllib.parse
 from typing import (
                    Callable,
-                   Dict,
-                   List,
                    Optional,
-                   Tuple,
                    TYPE_CHECKING,
                    Union,
                    )
@@ -26,7 +23,7 @@ NodeHandlerFnCallable = Callable[[WikiNode],
                                 Union[None, str, list, tuple, WikiNode]
                               ]
 
-kind_to_level: Dict[NodeKind, str] = {
+kind_to_level: dict[NodeKind, str] = {
     NodeKind.LEVEL2: "==",
     NodeKind.LEVEL3: "===",
     NodeKind.LEVEL4: "====",
@@ -36,7 +33,7 @@ kind_to_level: Dict[NodeKind, str] = {
 
 
 def to_attrs(node: WikiNode) -> str:
-    parts: List[str] = []
+    parts: list[str] = []
     for k, v in node.attrs.items():
         k = str(k)
         if not v:
@@ -58,7 +55,7 @@ def to_wikitext(node: WikiNode,
     WikiNodes in the returned value."""
     assert node_handler_fn is None or callable(node_handler_fn)
 
-    def recurse(node: Union[str, WikiNode, List, Tuple]) -> str:
+    def recurse(node: Union[str, WikiNode, list, tuple]) -> str:
         if isinstance(node, str):
             # Certain constructs needs to be protected so that they don't get
             # parsed when we convert back and forth between wikitext and parsed
@@ -79,7 +76,7 @@ def to_wikitext(node: WikiNode,
                 return recurse(ret)
 
         kind = node.kind
-        parts: List[str] = []
+        parts: list[str] = []
         if kind in kind_to_level:
             tag = kind_to_level[kind]
             t = recurse(node.largs)

--- a/src/wikitextprocessor/parser.py
+++ b/src/wikitextprocessor/parser.py
@@ -9,13 +9,9 @@ from collections.abc import Iterator
 from typing import (
     TYPE_CHECKING,
     Callable,
-    Dict,
-    List,
     Literal,
     Optional,
     overload,
-    Set,
-    Tuple,
     Union,
 )
 
@@ -34,7 +30,7 @@ if TYPE_CHECKING:
 
 
 # Set of tags that can be parents of "flow" parents
-HTML_FLOW_PARENTS: Set[str] = set(
+HTML_FLOW_PARENTS: set[str] = set(
     k
     for k, v in ALLOWED_HTML_TAGS.items()
     if "flow" in v.get("content", []) or "*" in v.get("content", [])
@@ -42,7 +38,7 @@ HTML_FLOW_PARENTS: Set[str] = set(
 
 # Set of tags that can be parents of "phrasing" parents (includes those
 # of flow parents since flow implies phrasing)
-HTML_PHRASING_PARENTS: Set[str] = set(
+HTML_PHRASING_PARENTS: set[str] = set(
     k
     for k, v in ALLOWED_HTML_TAGS.items()
     if "phrasing" in v.get("content", [])
@@ -51,7 +47,7 @@ HTML_PHRASING_PARENTS: Set[str] = set(
 )
 
 # Mapping from HTML tag or "text" to permitted parent tags
-HTML_PERMITTED_PARENTS: Dict[str, Set[str]] = {
+HTML_PERMITTED_PARENTS: dict[str, set[str]] = {
     k: (
         (
             HTML_FLOW_PARENTS
@@ -70,7 +66,7 @@ HTML_PERMITTED_PARENTS: Dict[str, Set[str]] = {
 HTML_PERMITTED_PARENTS["text"] = HTML_PHRASING_PARENTS
 
 # Set of HTML tag like names that we treat as literal without any warning
-SILENT_HTML_LIKE: Set[str] = set(
+SILENT_HTML_LIKE: set[str] = set(
     [
         "gu",
         "qu",
@@ -80,7 +76,7 @@ SILENT_HTML_LIKE: Set[str] = set(
 
 
 # MediaWiki magic words.  See https://www.mediawiki.org/wiki/Help:Magic_words
-MAGIC_WORDS: Set[str] = set(
+MAGIC_WORDS: set[str] = set(
     [
         "__NOTOC__",
         "__FORCETOC__",
@@ -230,7 +226,7 @@ class NodeKind(enum.Flag):
 
 
 # Maps subtitle token to its kind
-SUBTITLE_TO_KIND: Dict[str, NodeKind] = {
+SUBTITLE_TO_KIND: dict[str, NodeKind] = {
     "=": NodeKind.LEVEL1,
     "==": NodeKind.LEVEL2,
     "===": NodeKind.LEVEL3,
@@ -242,13 +238,13 @@ SUBTITLE_TO_KIND: Dict[str, NodeKind] = {
 
 # Maps subtitle node kind to its level.  Keys include all title/subtitle nodes
 # (this is also used like a set of all subtitle kinds, including the root).
-KIND_TO_LEVEL: Dict[NodeKind, int] = {
+KIND_TO_LEVEL: dict[NodeKind, int] = {
     v: len(k) for k, v in SUBTITLE_TO_KIND.items()
 }
 KIND_TO_LEVEL[NodeKind.ROOT] = 0
 
 # Node types that have arguments separated by the vertical bar (|)
-HAVE_ARGS_KINDS: Tuple[NodeKind, ...] = (
+HAVE_ARGS_KINDS: tuple[NodeKind, ...] = (
     NodeKind.LINK,
     NodeKind.TEMPLATE,
     NodeKind.TEMPLATE_ARG,
@@ -258,7 +254,7 @@ HAVE_ARGS_KINDS: Tuple[NodeKind, ...] = (
 
 
 # Node kinds that generate an error if they have not been properly closed.
-MUST_CLOSE_KINDS: Tuple[NodeKind, ...] = (
+MUST_CLOSE_KINDS: tuple[NodeKind, ...] = (
     NodeKind.ITALIC,
     NodeKind.BOLD,
     NodeKind.PRE,
@@ -289,7 +285,7 @@ inside_html_tags_re = re.compile(
 # Sometimes, args.append(children) happens, so those
 # lists can contain at least strings and WikiNodes.
 # I think there is no third list layer, maximum is args[x][y].
-WikiNodeChildrenList = List[Union[str, "WikiNode"]]
+WikiNodeChildrenList = list[Union[str, "WikiNode"]]
 WikiNodeArgsSublist = WikiNodeChildrenList  # XXX Currently identical to above
 # WikiNodeArgs = Union[str, # Just a string
 #                      List[
@@ -299,8 +295,8 @@ WikiNodeArgsSublist = WikiNodeChildrenList  # XXX Currently identical to above
 #                         ]
 #                     ]
 WikiNodeStrArg = str
-WikiNodeListArgs = List[Union[WikiNodeArgsSublist, WikiNodeChildrenList]]
-WikiNodeHTMLAttrsDict = Dict[str, str]  # XXX Probably not just HTML...
+WikiNodeListArgs = list[Union[WikiNodeArgsSublist, WikiNodeChildrenList]]
+WikiNodeHTMLAttrsDict = dict[str, str]  # XXX Probably not just HTML...
 
 
 class WikiNode:
@@ -342,7 +338,7 @@ class WikiNode:
 
     @overload
     def find_child(self, target_kinds: NodeKind, with_index: Literal[True]
-        ) -> Iterator[Tuple[int, "WikiNode"]]: ...
+        ) -> Iterator[tuple[int, "WikiNode"]]: ...
 
     @overload
     def find_child(
@@ -354,7 +350,7 @@ class WikiNode:
         self,
         target_kinds: NodeKind,
         with_index: bool = False,
-    ) -> Iterator[Union["WikiNode", Tuple[int, "WikiNode"]]]:
+    ) -> Iterator[Union["WikiNode", tuple[int, "WikiNode"]]]:
         """
         Find direct child nodes that match the target node type, also return
         the node index that could be used to divide child node list.
@@ -437,7 +433,7 @@ class WikiNode:
         with_index: Literal[False] = ...,
         attr_name: str = ...,
         attr_value: str = ...,
-    ) -> Iterator[Tuple[int, "HTMLNode"]]: ...
+    ) -> Iterator[tuple[int, "HTMLNode"]]: ...
 
     def find_html(
         self,
@@ -445,7 +441,7 @@ class WikiNode:
         with_index: bool = False,
         attr_name: str = "",
         attr_value: str = "",
-    ) -> Iterator[Union["HTMLNode", Tuple[int, "HTMLNode"]]]:
+    ) -> Iterator[Union["HTMLNode", tuple[int, "HTMLNode"]]]:
         # Find direct HTMl child nodes match the target tag and attribute.
         for index, node in self.find_child(NodeKind.HTML, True):
             if TYPE_CHECKING:
@@ -482,9 +478,9 @@ class TemplateNode(WikiNode):
     def __init__(self, linenum: int):
         super().__init__(NodeKind.TEMPLATE, linenum)
         self._template_parameters: Optional[
-            Dict[
+            dict[
                 Union[str, int],
-                Union[str, WikiNode, List[Union[str, WikiNode]]],
+                Union[str, WikiNode, list[Union[str, WikiNode]]],
             ]
         ] = None
 
@@ -495,8 +491,8 @@ class TemplateNode(WikiNode):
     @property
     def template_parameters(
         self,
-    ) -> Dict[
-        Union[str, int], Union[str, WikiNode, List[Union[str, WikiNode]]]
+    ) -> dict[
+        Union[str, int], Union[str, WikiNode, list[Union[str, WikiNode]]]
     ]:
         # Convert the list type arguments to a dictionary.
         if self._template_parameters is not None:
@@ -621,7 +617,7 @@ def _parser_merge_str_children(ctx: "Wtp") -> None:
     characters are expanded and nowiki characters removed."""
     node = ctx.parser_stack[-1]
     new_children: WikiNodeChildrenList = []
-    strings: List[str] = []
+    strings: list[str] = []
     for x in node.children:
         if isinstance(x, str):
             strings.append(x)
@@ -1280,7 +1276,7 @@ attr_assignments_re = re.compile(
 )  # to account for spaces between entities
 
 
-def check_for_attributes(ctx: "Wtp", node: WikiNode) -> Tuple[bool, str]:
+def check_for_attributes(ctx: "Wtp", node: WikiNode) -> tuple[bool, str]:
     """Check if the children of this node conform to the format of
     attribute assignment in tables"""
 
@@ -2009,7 +2005,7 @@ list_prefix_re = re.compile(r"[*:;#]+")
 
 # Dictionary mapping fixed form tokens to their handler functions.
 # Tokens that have variable form are handled in the code in token_iter().
-tokenops: Dict[str, Callable[["Wtp", str], None]] = {
+tokenops: dict[str, Callable[["Wtp", str], None]] = {
     "'''": bold_fn,
     "''": italic_fn,
     "[": elink_start_fn,
@@ -2033,7 +2029,7 @@ for x in MAGIC_WORDS:
     tokenops[x] = magicword_fn
 
 
-def bold_follows(parts: List[str], i: int) -> bool:
+def bold_follows(parts: list[str], i: int) -> bool:
     """Checks if there is a bold (''') in parts after parts[i].  We allow
     intervening italics ('')."""
     parts = parts[i + 1 :]
@@ -2045,7 +2041,7 @@ def bold_follows(parts: List[str], i: int) -> bool:
     return False
 
 
-def token_iter(ctx: "Wtp", text: str) -> Iterator[Tuple[bool, str]]:
+def token_iter(ctx: "Wtp", text: str) -> Iterator[tuple[bool, str]]:
     """Tokenizes MediaWiki page content.  This yields (is_token, text) for
     each token.  ``is_token`` is False for text and True for other tokens.
     Wikitext bold and italic are interpreted WITHIN A SINGLE LINE.  It seems
@@ -2055,7 +2051,7 @@ def token_iter(ctx: "Wtp", text: str) -> Iterator[Tuple[bool, str]]:
     # Replace single quotes inside HTML tags with MAGIC_SQUOTE_CHAR
     tag_parts = re.split(inside_html_tags_re, text)
     if len(tag_parts) > 1:
-        new_parts: List[str] = []
+        new_parts: list[str] = []
         for tp in tag_parts:
             if re.match(inside_html_tags_re, tp):
                 # we're inside an HTML tag

--- a/src/wikitextprocessor/parserfns.py
+++ b/src/wikitextprocessor/parserfns.py
@@ -8,7 +8,7 @@ import math
 import re
 import sys
 import urllib.parse
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
@@ -1641,7 +1641,7 @@ PARSER_FUNCTIONS = {
 def call_parser_function(
     ctx: "Wtp",
     fn_name: str,
-    args: Union[Dict[Union[int, str], str], List[str]],
+    args: Union[Dict[Union[int, str], str], Sequence[str]],
     expander: Callable[[str], str],
 ) -> str:
     """Calls the given parser function with the given arguments."""

--- a/src/wikitextprocessor/parserfns.py
+++ b/src/wikitextprocessor/parserfns.py
@@ -1486,13 +1486,13 @@ def statements_fn(
 
 
 def pagelanguage_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     return ctx.lang_code
 
 
 def language_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     if len(args) > 0:
         from mediawiki_langcodes import code_to_name

--- a/src/wikitextprocessor/parserfns.py
+++ b/src/wikitextprocessor/parserfns.py
@@ -10,7 +10,7 @@ import sys
 import urllib.parse
 from collections.abc import Callable, Sequence
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import dateparser
 
@@ -37,7 +37,7 @@ def capitalizeFirstOnly(s: str) -> str:
 
 
 def if_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements #if parser function."""
     # print(f"if_fn: {args}")
@@ -51,7 +51,7 @@ def if_fn(
 
 
 def ifeq_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements #ifeq parser function."""
     arg0: str = args[0] if args else ""
@@ -64,7 +64,7 @@ def ifeq_fn(
 
 
 def iferror_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the #iferror parser function."""
     arg0: str = expander(args[0]) if args else ""
@@ -80,7 +80,7 @@ def iferror_fn(
 
 
 def ifexpr_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements #ifexpr parser function."""
     arg0: str = args[0] if args else "0"
@@ -97,7 +97,7 @@ def ifexpr_fn(
 
 
 def ifexist_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements #ifexist parser function."""
     arg0 = args[0] if args else ""
@@ -109,7 +109,7 @@ def ifexist_fn(
 
 
 def switch_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements #switch parser function."""
     val = expander(args[0]).strip() if args else ""
@@ -137,7 +137,7 @@ def switch_fn(
 
 
 def categorytree_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable
 ) -> str:
     """Implements the #categorytree parser function.  This function accepts
     keyed arguments."""
@@ -148,7 +148,7 @@ def categorytree_fn(
 
 
 def lst_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the #lst (alias #section etc) parser function."""
     pagetitle = expander(args[0]).strip() if args else ""
@@ -162,7 +162,7 @@ def lst_fn(
         )
         return ""
 
-    parts: List[str] = []
+    parts: list[str] = []
     for m in re.finditer(
         r"(?si)<\s*section\s+begin={}\s*/\s*>(.*?)"
         r"<\s*section\s+end={}\s*/\s*>".format(
@@ -182,7 +182,7 @@ def lst_fn(
 
 
 def tag_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements #tag parser function."""
     tag = expander(args[0]).lower() if args else ""
@@ -225,7 +225,7 @@ def tag_fn(
 
 
 def fullpagename_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the FULLPAGENAME magic word/parser function."""
     t = expander(args[0]) if args else ctx.title
@@ -246,7 +246,7 @@ def fullpagename_fn(
 
 
 def fullpagenamee_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the FULLPAGENAMEE magic word/parser function."""
     t = fullpagename_fn(ctx, fn_name, args, expander)
@@ -254,7 +254,7 @@ def fullpagenamee_fn(
 
 
 def pagenamee_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the PAGENAMEE magic word/parser function."""
     t = pagename_fn(ctx, fn_name, args, expander)
@@ -262,7 +262,7 @@ def pagenamee_fn(
 
 
 def rootpagenamee_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the ROOTPAGENAMEE magic word/parser function."""
     t = rootpagename_fn(ctx, fn_name, args, expander)
@@ -270,7 +270,7 @@ def rootpagenamee_fn(
 
 
 def pagename_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the PAGENAME magic word/parser function."""
     t = expander(args[0]) if args else ctx.title
@@ -286,7 +286,7 @@ def pagename_fn(
 
 
 def basepagename_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the BASEPAGENAME magic word/parser function."""
     t = expander(args[0]) if args else ctx.title
@@ -299,7 +299,7 @@ def basepagename_fn(
 
 
 def rootpagename_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the ROOTPAGENAME magic word/parser function."""
     t = expander(args[0]) if args else ctx.title
@@ -312,7 +312,7 @@ def rootpagename_fn(
 
 
 def subpagename_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the SUBPAGENAME magic word/parser function."""
     t = expander(args[0]) if args else ctx.title
@@ -326,7 +326,7 @@ def subpagename_fn(
 
 
 def talkpagename_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the TALKPAGENAME magic word."""
     ofs = ctx.title.find(":")
@@ -344,7 +344,7 @@ def talkpagename_fn(
 
 
 def namespacenumber_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the NAMESPACENUMBER magic word/parser function."""
     # XXX currently hard-coded to return the name space number for the Main
@@ -353,7 +353,7 @@ def namespacenumber_fn(
 
 
 def namespace_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the NAMESPACE magic word/parser function."""
     t = expander(args[0]) if args else ctx.title
@@ -369,7 +369,7 @@ def namespace_fn(
 
 
 def subjectspace_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the SUBJECTSPACE magic word/parser function.  This
     implementation is very minimal."""
@@ -381,7 +381,7 @@ def subjectspace_fn(
 
 
 def talkspace_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the TALKSPACE magic word/parser function.  This
     implementation is very minimal."""
@@ -393,42 +393,42 @@ def talkspace_fn(
 
 
 def server_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the SERVER magic word."""
     return "//" + servername_fn(ctx, fn_name, args, expander)
 
 
 def servername_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the SERVERNAME magic word."""
     return f"{ctx.lang_code}.{ctx.project}.org"
 
 
 def currentyear_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the CURRENTYEAR magic word."""
     return str(datetime.now(timezone.utc).year)
 
 
 def currentmonth_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the CURRENTMONTH magic word."""
     return datetime.now(timezone.utc).strftime("%m")
 
 
 def currentmonth1_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the CURRENTMONTH1 magic word."""
     return str(datetime.now(timezone.utc).month)
 
 
 def currentmonthname_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the CURRENTMONTHNAME magic word."""
     # XXX support for other languages?
@@ -436,7 +436,7 @@ def currentmonthname_fn(
 
 
 def currentmonthabbrev_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the CURRENTMONTHABBREV magic word."""
     # XXX support for other languages?
@@ -444,28 +444,28 @@ def currentmonthabbrev_fn(
 
 
 def currentday_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the CURRENTDAY magic word."""
     return str(datetime.now(timezone.utc).day)
 
 
 def currentday2_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the CURRENTDAY2 magic word."""
     return datetime.now(timezone.utc).strftime("%d")
 
 
 def currentdow_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the CURRENTDOW magic word."""
     return str(datetime.now(timezone.utc).weekday())
 
 
 def revisionid_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the REVISIONID magic word."""
     # We just return a dash, similar to "miser mode" in MediaWiki."""
@@ -473,7 +473,7 @@ def revisionid_fn(
 
 
 def revisionuser_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the REVISIONUSER magic word."""
     # We always return AnonymousUser
@@ -481,7 +481,7 @@ def revisionuser_fn(
 
 
 def displaytitle_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the DISPLAYTITLE magic word/parser function."""
     # t = expander(args[0]) if args else ""
@@ -494,7 +494,7 @@ def displaytitle_fn(
 
 
 def defaultsort_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the DEFAULTSORT magic word/parser function."""
     # XXX apparently this should set the title by which this page is
@@ -503,14 +503,14 @@ def defaultsort_fn(
 
 
 def lc_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the lc parser function (lowercase)."""
     return expander(args[0]).strip().lower() if args else ""
 
 
 def lcfirst_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the lcfirst parser function (lowercase first character)."""
     t = expander(args[0]).strip() if args else ""
@@ -520,7 +520,7 @@ def lcfirst_fn(
 
 
 def uc_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the uc parser function (uppercase)."""
     t = expander(args[0]).strip() if args else ""
@@ -528,7 +528,7 @@ def uc_fn(
 
 
 def ucfirst_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the ucfirst parser function (capitalize first character)."""
     t = expander(args[0]).strip() if args else ""
@@ -536,7 +536,7 @@ def ucfirst_fn(
 
 
 def formatnum_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the formatnum parser function."""
     arg0 = expander(args[0]).strip() if args else ""
@@ -565,7 +565,7 @@ def formatnum_fn(
 
 
 def dateformat_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the #dateformat (= #formatdate) parser function."""
     arg0 = expander(args[0]) if args else ""
@@ -606,7 +606,7 @@ def dateformat_fn(
 
 
 def localurl_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the localurl parser function."""
     arg0 = expander(args[0]).strip() if args else ctx.title
@@ -622,7 +622,7 @@ def localurl_fn(
 
 
 def fullurl_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """
     Implements the fullurl and fullurle parser function.
@@ -648,7 +648,7 @@ def fullurl_fn(
 
 
 def urlencode_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the urlencode parser function."""
     arg0 = expander(args[0]) if args else ""
@@ -669,7 +669,7 @@ def wikiurlencode(url: str) -> str:
 
 
 def anchorencode_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the urlencode parser function."""
     anchor = expander(args[0]).strip() if args else ""
@@ -707,7 +707,7 @@ class Namespace:
 
     def __init__(
         self,
-        aliases: Optional[List[str]] = None,
+        aliases: Optional[list[str]] = None,
         canonicalName="",
         defaultContentModel="wikitext",
         hasGenderDistinction=True,
@@ -726,7 +726,7 @@ class Namespace:
         assert id is not None
         if aliases is None:
             aliases = []
-        self.aliases: List[str] = aliases
+        self.aliases: list[str] = aliases
         self.canonicalName = canonicalName
         self.defaultContentModel = defaultContentModel
         self.hasGenderDistinction = hasGenderDistinction
@@ -762,7 +762,7 @@ def init_namespaces(ctx: "Wtp") -> None:
 
 
 def ns_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the ns parser function."""
     t = expander(args[0]).strip().upper() if args else ""
@@ -789,7 +789,7 @@ def ns_fn(
 
 
 def titleparts_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the #titleparts parser function."""
     t = expander(args[0]).strip() if args else ""
@@ -825,7 +825,7 @@ BinaryCallable = Callable[
 UnaryCallable = Callable[[Union[int, float]], Union[int, float, str]]
 
 # Supported unary functions for #expr
-unary_fns: Dict[str, UnaryCallable] = {
+unary_fns: dict[str, UnaryCallable] = {
     "-": lambda x: -x,  # Kludge to have this here besides parse_unary
     "+": lambda x: x,  # Kludge to have this here besides parse_unary
     "not": lambda x: int(not x),
@@ -863,31 +863,31 @@ def binary_e_fn(
     return x * math.pow(10, y)
 
 
-binary_e_fns: Dict[str, BinaryCallable] = {
+binary_e_fns: dict[str, BinaryCallable] = {
     "e": binary_e_fn,
 }
 
-binary_pow_fns: Dict[str, BinaryCallable] = {
+binary_pow_fns: dict[str, BinaryCallable] = {
     "^": math.pow,
 }
 
-binary_mul_fns: Dict[str, BinaryCallable] = {
+binary_mul_fns: dict[str, BinaryCallable] = {
     "*": lambda x, y: x * y,
     "/": lambda x, y: "Divide by zero" if y == 0 else x / y,
     "div": lambda x, y: "Divide by zero" if y == 0 else x / y,
     "mod": lambda x, y: "Divide by zero" if y == 0 else x % y,
 }
 
-binary_add_fns: Dict[str, BinaryCallable] = {
+binary_add_fns: dict[str, BinaryCallable] = {
     "+": lambda x, y: x + y,
     "-": lambda x, y: x - y,
 }
 
-binary_round_fns: Dict[str, BinaryCallable] = {
+binary_round_fns: dict[str, BinaryCallable] = {
     "round": round,  # type:ignore
 }
 
-binary_cmp_fns: Dict[str, BinaryCallable] = {
+binary_cmp_fns: dict[str, BinaryCallable] = {
     "=": lambda x, y: int(x == y),
     "!=": lambda x, y: int(x != y),
     "<>": lambda x, y: int(x != y),
@@ -897,17 +897,17 @@ binary_cmp_fns: Dict[str, BinaryCallable] = {
     "<=": lambda x, y: int(x <= y),
 }
 
-binary_and_fns: Dict[str, BinaryCallable] = {
+binary_and_fns: dict[str, BinaryCallable] = {
     "and": lambda x, y: 1 if x and y else 0,
 }
 
-binary_or_fns: Dict[str, BinaryCallable] = {
+binary_or_fns: dict[str, BinaryCallable] = {
     "or": lambda x, y: 1 if x or y else 0,
 }
 
 
 def expr_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the #titleparts parser function."""
     full_expr = expander(args[0]).strip().lower() if args else ""
@@ -976,7 +976,7 @@ def expr_fn(
     def generic_binary(
         tok: Optional[str],
         parser: Callable,
-        fns: Dict[str, Callable],
+        fns: dict[str, Callable],
         assoc="left",
     ) -> Union[int, float, str]:
         ret = parser(tok)
@@ -1059,7 +1059,7 @@ def expr_fn(
 
 
 def padleft_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the padleft parser function."""
     v = expander(args[0]) if args else ""
@@ -1084,7 +1084,7 @@ def padleft_fn(
 
 
 def padright_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the padright parser function."""
     v = expander(args[0]) if args else ""
@@ -1110,7 +1110,7 @@ def padright_fn(
 
 
 def plural_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the #plural parser function."""
     expr = expander(args[0]).strip() if args else "0"
@@ -1131,7 +1131,7 @@ def month_num_days(ctx: "Wtp", t: datetime) -> int:
     return v
 
 
-time_fmt_map: Dict[
+time_fmt_map: dict[
     str,
     Union[str, Callable[["Wtp", datetime], Union[int, float, str]]],
 ] = {
@@ -1181,7 +1181,7 @@ time_fmt_map: Dict[
 
 
 def time_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the #time parser function."""
     fmt = expander(args[0]).strip() if args else ""
@@ -1272,7 +1272,7 @@ def time_fn(
 
 
 def len_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the #len parser function."""
     v = expander(args[0]).strip() if args else ""
@@ -1280,7 +1280,7 @@ def len_fn(
 
 
 def pos_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the #pos parser function."""
     arg0 = expander(args[0]).strip() if args else ""
@@ -1297,7 +1297,7 @@ def pos_fn(
 
 
 def rpos_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the #rpos parser function."""
     arg0 = expander(args[0]).strip() if args else ""
@@ -1314,7 +1314,7 @@ def rpos_fn(
 
 
 def sub_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the #sub parser function."""
     arg0 = expander(args[0]).strip() if args else ""
@@ -1339,7 +1339,7 @@ def sub_fn(
 
 
 def pad_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the pad parser function."""
     v = expander(args[0]).strip() if args else ""
@@ -1368,7 +1368,7 @@ def pad_fn(
 
 
 def replace_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the #replace parser function."""
     arg0 = expander(args[0]).strip() if args else ""
@@ -1378,7 +1378,7 @@ def replace_fn(
 
 
 def explode_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the #explode parser function."""
     arg0 = expander(args[0]).strip() if args else ""
@@ -1404,7 +1404,7 @@ def explode_fn(
 
 
 def urldecode_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     """Implements the #urldecode parser function."""
     arg0 = expander(args[0]).strip() if args else ""
@@ -1413,14 +1413,14 @@ def urldecode_fn(
 
 
 def shortdesc_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     # https://en.wikipedia.org/wiki/Wikipedia:Short_description
     return ""
 
 
 def unimplemented_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     ctx.error(
         "unimplemented parserfn {}".format(fn_name), sortid="parserfns/1191"
@@ -1473,7 +1473,7 @@ def _query_wikidata_statement(prop: str, item: str, lang_code: str) -> str:
 
 
 def statements_fn(
-    ctx: "Wtp", fn_name: str, args: List[str], expander: Callable[[str], str]
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     # https://www.wikidata.org/wiki/Wikidata:How_to_use_data_on_Wikimedia_projects
     prop = ""
@@ -1641,7 +1641,7 @@ PARSER_FUNCTIONS = {
 def call_parser_function(
     ctx: "Wtp",
     fn_name: str,
-    args: Union[Dict[Union[int, str], str], Sequence[str]],
+    args: Union[dict[Union[int, str], str], Sequence[str]],
     expander: Callable[[str], str],
 ) -> str:
     """Calls the given parser function with the given arguments."""

--- a/src/wikitextprocessor/wikihtml.py
+++ b/src/wikitextprocessor/wikihtml.py
@@ -24,17 +24,17 @@
 # close-next lists tags that automatically close this tag.  Closing a
 # parent tag will also silently close them.  Otherwise a missing end tag
 # results in an error message.
-from typing import Dict, List, TypedDict 
+from typing import TypedDict 
 
 HTMLTagData = TypedDict('HTMLTagData',
-                        {"parents": List[str],
-                         "content": List[str],
-                         "close-next": List[str],
+                        {"parents": list[str],
+                         "content": list[str],
+                         "close-next": list[str],
                          "no-end-tag": bool,
                         },
                          total=False) # Do not require all to be present
 
-ALLOWED_HTML_TAGS: Dict[str, HTMLTagData] = {
+ALLOWED_HTML_TAGS: dict[str, HTMLTagData] = {
     "a": {
         "parents": ["phrasing"],
         "content": ["flow"]},


### PR DESCRIPTION
Updating the syntax to Python 3.9 type hinting, also attempted to take care of a few 3.9-specific issues (like function signatures that have been changed since 3.9, but still have a 3.9-friendly 'form' that can be used).