### PR TITLE
Add a flag variable of level node kinds

### DIFF
--- a/src/wikitextprocessor/parser.py
+++ b/src/wikitextprocessor/parser.py
@@ -244,6 +244,16 @@ KIND_TO_LEVEL: dict[NodeKind, int] = {
 }
 KIND_TO_LEVEL[NodeKind.ROOT] = 0
 
+# This variable could be used in `WikiNode.find_child()` to search level nodes
+LEVEL_KIND_FLAGS = (
+    NodeKind.LEVEL1
+    | NodeKind.LEVEL2
+    | NodeKind.LEVEL3
+    | NodeKind.LEVEL4
+    | NodeKind.LEVEL5
+    | NodeKind.LEVEL6
+)
+
 # Node types that have arguments separated by the vertical bar (|)
 HAVE_ARGS_KINDS: tuple[NodeKind, ...] = (
     NodeKind.LINK,


### PR DESCRIPTION
It's convenient to have this value to search level nodes or check if a node is level node.