### PR TITLE
Transclude any page as template

### DIFF
--- a/src/wikitextprocessor/luaexec.py
+++ b/src/wikitextprocessor/luaexec.py
@@ -5,6 +5,7 @@
 
 import copy
 import html
+import html.entities
 import json
 import multiprocessing  # XXX debug, remove me
 import re

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2190,11 +2190,13 @@ def foo(x):
             self.assertEqual(self.ctx.errors, [])
 
     def test_file_Babel(self):
+        self.ctx.add_page("Template:isValidPageName", 10, "")
         with open("tests/Babel.txt", "r") as f:
             self.parse("Babel", f.read(), pre_expand=True)
             self.assertEqual(self.ctx.errors, [])
 
     def test_file_fi_gradation(self):
+        self.ctx.add_page("Template:fi-gradation-row", 10, "")
         with open("tests/fi-gradation.txt", "r") as f:
             self.parse("fi-gradation", f.read(), pre_expand=True)
             self.assertEqual(self.ctx.errors, [])

--- a/tests/test_wikiprocess.py
+++ b/tests/test_wikiprocess.py
@@ -4212,6 +4212,28 @@ return export
                 self.assertEqual(self.ctx.expand(wikitext), result)
         mock_get_interwiki_data.assert_called_once()
 
+    def test_transclude_page(self):
+        # https://fr.wiktionary.org/wiki/Conjugaison:français/s’abêtir
+        # The "Conjugaison" namespace name is replaced with "Sign gloss" that
+        # has the same namesapce id.
+        self.ctx.start_page("")
+        self.ctx.add_page(
+            "Sign gloss:français/abêtir",
+            116,
+            "{{Onglets conjugaison| sél ={{{sél|1}}}}}",
+        )
+        self.ctx.add_page("Template:Onglets conjugaison", 10, "{{{sél|1}}}")
+        self.ctx.add_page("Template:Foo:bar", 10, "foobar")
+        self.ctx.add_page("page", 0, "page text")
+        self.assertEqual(
+            self.ctx.expand("{{:Sign gloss:français/abêtir|sél=2}}"), "2"
+        )
+        self.assertEqual(self.ctx.expand("{{:page}}"), "page text")
+        self.assertEqual(
+            self.ctx.expand("{{Template:Onglets conjugaison|sél = 3}}"), "3"
+        )
+        self.assertEqual(self.ctx.expand("{{Foo:bar}}"), "foobar")
+
 
 # XXX Test template_fn
 


### PR DESCRIPTION
Any page can be used as template:
https://www.mediawiki.org/wiki/Help:Templates#Usage

This feature is used in French Wiktionary's Conjugaison page.