### PR TITLE
Fix 'WikiNode' object has no attribute 'strip' error

### DIFF
--- a/src/wikitextprocessor/parser.py
+++ b/src/wikitextprocessor/parser.py
@@ -506,7 +506,10 @@ class TemplateNode(WikiNode):
 
     @property
     def template_name(self) -> str:
-        return self.largs[0][0].strip()  # type: ignore[union-attr]
+        if isinstance(self.largs[0][0], str):
+            return self.largs[0][0].strip()
+        else:
+            return "<WikiNode>"
 
     @property
     def template_parameters(self) -> TemplateParameters:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2615,6 +2615,14 @@ def foo(x):
             self.ctx.expand("{{fr-conj/Tableau-composé|'aux.1s=oui}}"), "oui"
         )
 
+    def test_wikinode_as_template_name(self):
+        # https://fr.wiktionary.org/wiki/trempage
+        # a link is mistakenly used as template name
+        self.ctx.start_page("")
+        root = self.ctx.parse("{{{{foo}}|bar}}")
+        t_node = root.children[0]
+        self.assertEqual(t_node.template_name, "<WikiNode>")
+
 
 # XXX implement <nowiki/> marking for links, templates
 #  - https://en.wikipedia.org/wiki/Help:Wikitext#Nowiki


### PR DESCRIPTION
Can't expand nodes at here, and this error happens on a misuse of link as template name. Not sure if there are real usage of template for a template name, probably not very common.