### PR TITLE
Don't match HTML end tag as start tag in arguments

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -529,11 +529,11 @@ class Wtp:
                     # re.X = ignore whitespace and comments, re.I = ignore case
                     r"""(?xi)\|(
                             (
-                                <([-a-zA-Z0-9]+)\b[^>]*>  # html tag
-                                    [^][{}]*?             # element contents
-                                                          # (including `|`'s)
-                                    </\3\s*>              # end tag
-                            |   [^|]            # everything else
+                                <([-a-zA-Z0-9]+)\b[^>]*(?<!/)>  # html start tag
+                                    [^][{}]*?  # element contents
+                                               # (including `|`'s)
+                                    </\3\s*>   # end tag
+                            |   [^|]           # everything else
                             )*
                           )""",
                     "|" + v,  # first/only argument needs a vbar

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2623,6 +2623,17 @@ def foo(x):
         t_node = root.children[0]
         self.assertEqual(t_node.template_name, "<WikiNode>")
 
+    def test_html_end_tag_in_parserfn(self):
+        # https://fr.wiktionary.org/wiki/Modèle:fr-conj/Tableau-composé
+        # the parser should be able to parse the second argument
+        self.ctx.start_page("")
+        self.ctx.add_page(
+            "Template:t",
+            10,
+            "{{#if:|<nowiki /> t{{#if:|’|e <nowiki />}}|<nowiki> </nowiki>}}",
+        )
+        self.assertEqual(self.ctx.expand("{{t}}"), "<nowiki> </nowiki>")
+
 
 # XXX implement <nowiki/> marking for links, templates
 #  - https://en.wikipedia.org/wiki/Help:Wikitext#Nowiki


### PR DESCRIPTION
The previous regex pattern matches `<nowiki />` as a start tag therefore includes the second "if" argument into the first argument.