### PR TITLE
Only match table row token at the beginning of a line

### DIFF
--- a/src/wikitextprocessor/parser.py
+++ b/src/wikitextprocessor/parser.py
@@ -1977,7 +1977,7 @@ header_re = re.compile(r"(?m)^(={1,6})\s*(([^=]|=[^=])+?)\s*(={1,6})\s*$")
 
 # Regular expression for matching a token in WikiMedia text.  This is used for
 # tokenizing the input.
-token_re = re.compile(
+TOKEN_RE = re.compile(
     r"'''''|"
     r"'''|"
     r"''|"
@@ -1986,8 +1986,8 @@ token_re = re.compile(
     r"\]|"
     r"\|\}|"
     r"\{\||"
-    r"\|\+|"
-    r"\|-|"
+    r"^\s*\|\+|"  # table caption
+    r"^\s*\|-|"  # table row
     r"!!|"
     r"\s*https?://[a-zA-Z0-9.]+(/[^][{}<>|\s]*)?|"
     r"^[ \t]*!|"
@@ -2165,7 +2165,7 @@ def token_iter(ctx: "Wtp", text: str) -> Iterator[tuple[bool, str]]:
             pos = 0
             # Revert to single quotes from MAGIC_SQUOTE_CHAR
             part = part.replace(MAGIC_SQUOTE_CHAR, "'")
-            for m in re.finditer(token_re, part):
+            for m in re.finditer(TOKEN_RE, part):
                 start = m.start()
                 if pos != start:
                     yield False, part[pos:start]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2634,6 +2634,24 @@ def foo(x):
         )
         self.assertEqual(self.ctx.expand("{{t}}"), "<nowiki> </nowiki>")
 
+    def test_hypen_in_table_cell(self):
+        # https://fr.wiktionary.org/wiki/Conjugaison:français/s’abattre
+        # "|-toi" is table cell not table row
+        self.ctx.start_page("")
+        root = self.ctx.parse(
+            """{|
+|-
+|width="25%"|-toi
+|}"""
+        )
+        table_node = root.children[0]
+        self.assertEqual(table_node.kind, NodeKind.TABLE)
+        table_row = table_node.children[0]
+        self.assertEqual(table_row.kind, NodeKind.TABLE_ROW)
+        table_cell = table_row.children[0]
+        self.assertEqual(table_cell.kind, NodeKind.TABLE_CELL)
+        self.assertEqual(table_cell.children, ["-toi\n"])
+
 
 # XXX implement <nowiki/> marking for links, templates
 #  - https://en.wikipedia.org/wiki/Help:Wikitext#Nowiki


### PR DESCRIPTION
table cell text might also starts with `-`