### PR TITLE
Accept whitespace before certain table tokens

### DIFF
--- a/tests/test_node_expand.py
+++ b/tests/test_node_expand.py
@@ -142,8 +142,10 @@ class NodeExpTests(unittest.TestCase):
             "[https://wikipedia.org/x/y?a=7%255]",
         )
 
-    def test_table1(self):
-        self.backcvt("{| |}", "\n{| \n\n|}\n")
+    # This test is incorrect: the |} token requires it to be on a new
+    # line, after ^\n\s*
+    # def test_table1(self):
+    #     self.backcvt("{| |}", "\n{| \n\n|}\n")
 
     def test_table2(self):
         self.backcvt('{| class="x"\n|}', '\n{| class="x"\n\n|}\n')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2636,6 +2636,59 @@ def foo(x):
         )
         self.assertEqual(self.ctx.expand("{{t}}"), "<nowiki> </nowiki>")
 
+    def test_hypen_in_table_cell(self):
+        # https://fr.wiktionary.org/wiki/Conjugaison:français/s’abattre
+        # "|-toi" is table cell not table row
+        self.ctx.start_page("")
+        root = self.ctx.parse(
+            """{|
+|-
+|width="25%"|-toi
+|}"""
+        )
+        table_node = root.children[0]
+        self.assertEqual(table_node.kind, NodeKind.TABLE)
+        table_row = table_node.children[0]
+        self.assertEqual(table_row.kind, NodeKind.TABLE_ROW)
+        table_cell = table_row.children[0]
+        self.assertEqual(table_cell.kind, NodeKind.TABLE_CELL)
+        self.assertEqual(table_cell.children, ["-toi\n"])
+
+    def test_plus_in_table_cell(self):
+        # Based on above test
+        self.ctx.start_page("")
+        root = self.ctx.parse(
+            """{|
+|-
+|width="25%"|+toi
+|}"""
+        )
+        table_node = root.children[0]
+        self.assertEqual(table_node.kind, NodeKind.TABLE)
+        table_row = table_node.children[0]
+        self.assertEqual(table_row.kind, NodeKind.TABLE_ROW)
+        table_cell = table_row.children[0]
+        self.assertEqual(table_cell.kind, NodeKind.TABLE_CELL)
+        self.assertEqual(table_cell.children, ["+toi\n"])
+
+    def test_curly_in_table_cell(self):
+        self.ctx.start_page("")
+        root = self.ctx.parse(
+            """{|
+|Test{||}Test2
+|}"""
+        )
+        table_node = root.children[0]
+        self.assertEqual(table_node.kind, NodeKind.TABLE)
+        table_row = table_node.children[0]
+        self.assertEqual(table_row.kind, NodeKind.TABLE_ROW)
+        table_cell = table_row.children[0]
+        self.assertEqual(table_cell.kind, NodeKind.TABLE_CELL)
+        self.assertEqual(table_cell.children, ["Test{"])
+        table_cell = table_row.children[1]
+        self.assertEqual(table_cell.kind, NodeKind.TABLE_CELL)
+        self.assertEqual(table_cell.children, ["}Test2\n"])
+
 
 # XXX implement <nowiki/> marking for links, templates
 #  - https://en.wikipedia.org/wiki/Help:Wikitext#Nowiki

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1539,7 +1539,7 @@ def foo(x):
         self.assertEqual(b.children, [])
 
     def test_table_empty(self):
-        tree = self.parse("test", "{| |}")
+        tree = self.parse("test", "{| \n |}")
         self.assertEqual(len(tree.children), 1)
         t = tree.children[0]
         self.assertEqual(t.kind, NodeKind.TABLE)
@@ -1761,6 +1761,8 @@ def foo(x):
         c, h, a, b = t.children
         self.assertEqual(c.kind, NodeKind.TABLE_CAPTION)
         self.assertEqual(c.attrs.get("class"), "caption")
+        # XXX "||text\n" should be discarded, if we follow wikitext
+        # Left this here as an XXX because... This is an ok fail state for us.
         self.assertEqual(c.children, ["cap!!tion!||text\n"])
         self.assertEqual(h.kind, NodeKind.TABLE_ROW)
         self.assertEqual(len(h.children), 3)
@@ -2012,12 +2014,12 @@ def foo(x):
         self.assertEqual(len(self.ctx.debugs), 1)
 
     def test_error10(self):
-        self.parse("test", "{| ''\n|-\n'' |}")
+        self.parse("test", "{| ''\n|-\n'' \n|}")
         self.assertEqual(self.ctx.warnings, [])  # Warning now disabled
         self.assertEqual(self.ctx.debugs, [])  # Warning now disabled
 
     def test_error11(self):
-        self.parse("test", "{| ''\n|+\n'' |}")
+        self.parse("test", "{| ''\n|+\n'' \n|}")
         self.assertEqual(self.ctx.warnings, [])  # Warning now disabled
         self.assertEqual(self.ctx.debugs, [])  # Warning now disabled
 


### PR DESCRIPTION
Previously, tokens such as `{|`, `|+`, `|-` and `|}` were allowed to function as tokens for parsing tables even when they weren't at the beginning of a line, or following whitespace at the beginning of a line. This is incorrect.

`|` and `!` (separating headers and cells) when singular need to be at the start of the line or after start of line whitespace, but not `||` and `!!` which are used within a line. `|` is a bit more complicated because the `|` token is also used an attribute separator in tables!

Had to change a few mistaken tables. `{| |}` results in broken tables because the `|}` is not parsed without a newline, and our parser will consume the rest of the section or document. Wikimedia's parser does something weird, and in this case the empty table above (without a proper end token, so it's parsed wonkily) moves forward in text until it encounters the end of the document or another table and then puts an empty table. So if you have a string after the text above, the string is *before* the empty HTML-table. It's weird, and we will at least for now keep this edgecase as it is.