### PR TITLE
Fix template expansion recursion too deep error

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -1502,7 +1502,8 @@ class Wtp:
                         # print("TEMPLATE_FN {}: {} {} -> {}"
                         #      .format(template_fn, name, ht, repr(t)))
                     if t is None:
-                        ns_id = self.NAMESPACE_DATA["Template"]["id"]
+                        template_ns = self.NAMESPACE_DATA["Template"]
+                        ns_id = template_ns["id"]
                         if ":" in name:
                             # https://www.mediawiki.org/wiki/Help:Templates#Usage
                             # transclude page {{:ns_name:title}} or {{:title}}
@@ -1543,11 +1544,8 @@ class Wtp:
                                 encoded_body, new_parent, expand_all
                             )
                         else:
-                            parts.append(
-                                f'<strong class="error">Template:{name}'
-                                + "</strong>"
-                            )
-                            continue
+                            # template doesn't exist
+                            t = f"[[:{template_ns['name']}:{name}]]"
 
                     # If a post_template_fn has been supplied, call it now
                     # to capture or alter the expansion

--- a/tests/test_wikiprocess.py
+++ b/tests/test_wikiprocess.py
@@ -112,14 +112,13 @@ return export
     def test_basic4(self):
         self.parserfn(
             "Some {{unknown template}} x",
-            'Some <strong class="error">Template:unknown template'
-            "</strong> x",
+            "Some [[:Template:unknown template]] x",
         )
 
     def test_basic5(self):
         self.parserfn(
             "Some {{unknown template|arg1||arg3}}",
-            'Some <strong class="error">Template:unknown template' "</strong>",
+            "Some [[:Template:unknown template]]",
         )
 
     def test_basic6(self):


### PR DESCRIPTION
[Module:debug/track](https://en.wiktionary.org/wiki/Module:debug/track) expands tracking templates through the Lua frame "expandTemplate" method. The previous code doesn't remove the template name from `Wtp.expand_stack` when template doesn't exist and causes the stack grow too much longer.

The previous code shouldn't skip this line: https://github.com/tatuylonen/wikitextprocessor/blob/8dc20c04ab68fc9c28bcaf751490a14b0fd0fbc8/src/wikitextprocessor/core.py#L1563

Error code: https://github.com/tatuylonen/wikitextprocessor/blob/8dc20c04ab68fc9c28bcaf751490a14b0fd0fbc8/src/wikitextprocessor/core.py#L1365-L1369 

Errors on kaikki.org: https://kaikki.org/dictionary/errors/details-too-deep-recursion-during-template-expansion.html