### PR TITLE
Fix Lua module not found error in Russian Wiktionary

### DIFF
--- a/src/wikitextprocessor/data/ru/namespaces.json
+++ b/src/wikitextprocessor/data/ru/namespaces.json
@@ -1,1 +1,317 @@
-{"Media": {"id": -2, "name": "\u041c\u0435\u0434\u0438\u0430", "content": false, "aliases": [], "issubject": true, "istalk": false}, "Special": {"id": -1, "name": "\u0421\u043b\u0443\u0436\u0435\u0431\u043d\u0430\u044f", "content": false, "aliases": [], "issubject": true, "istalk": false}, "Main": {"id": 0, "name": "Main", "content": true, "aliases": [], "issubject": true, "istalk": false}, "Talk": {"id": 1, "name": "\u041e\u0431\u0441\u0443\u0436\u0434\u0435\u043d\u0438\u0435", "content": false, "aliases": [], "issubject": false, "istalk": true}, "User": {"id": 2, "name": "\u0423\u0447\u0430\u0441\u0442\u043d\u0438\u0446\u0430", "content": false, "aliases": ["\u0423\u0447\u0430\u0441\u0442\u043d\u0438\u043a"], "issubject": true, "istalk": false}, "User talk": {"id": 3, "name": "\u041e\u0431\u0441\u0443\u0436\u0434\u0435\u043d\u0438\u0435 \u0443\u0447\u0430\u0441\u0442\u043d\u0438\u0446\u044b", "content": false, "aliases": ["\u041e\u0431\u0441\u0443\u0436\u0434\u0435\u043d\u0438\u0435 \u0443\u0447\u0430\u0441\u0442\u043d\u0438\u043a\u0430"], "issubject": false, "istalk": true}, "Project": {"id": 4, "name": "\u0412\u0438\u043a\u0438\u043f\u0435\u0434\u0438\u044f", "content": false, "aliases": ["WT"], "issubject": true, "istalk": false}, "Project talk": {"id": 5, "name": "\u041e\u0431\u0441\u0443\u0436\u0434\u0435\u043d\u0438\u0435 \u0412\u0438\u043a\u0438\u043f\u0435\u0434\u0438\u0438", "content": false, "aliases": [], "issubject": false, "istalk": true}, "File": {"id": 6, "name": "\u0424\u0430\u0439\u043b", "content": false, "aliases": ["Image"], "issubject": true, "istalk": false}, "File talk": {"id": 7, "name": "\u041e\u0431\u0441\u0443\u0436\u0434\u0435\u043d\u0438\u0435 \u0444\u0430\u0439\u043b\u0430", "content": false, "aliases": ["Image talk"], "issubject": false, "istalk": true}, "MediaWiki": {"id": 8, "name": "MediaWiki", "content": false, "aliases": [], "issubject": true, "istalk": false}, "MediaWiki talk": {"id": 9, "name": "\u041e\u0431\u0441\u0443\u0436\u0434\u0435\u043d\u0438\u0435 MediaWiki", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Template": {"id": 10, "name": "\u0428\u0430\u0431\u043b\u043e\u043d", "content": false, "aliases": ["T"], "issubject": true, "istalk": false}, "Template talk": {"id": 11, "name": "\u041e\u0431\u0441\u0443\u0436\u0434\u0435\u043d\u0438\u0435 \u0448\u0430\u0431\u043b\u043e\u043d\u0430", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Help": {"id": 12, "name": "\u0421\u043f\u0440\u0430\u0432\u043a\u0430", "content": false, "aliases": [], "issubject": true, "istalk": false}, "Help talk": {"id": 13, "name": "\u041e\u0431\u0441\u0443\u0436\u0434\u0435\u043d\u0438\u0435 \u0441\u043f\u0440\u0430\u0432\u043a\u0438", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Category": {"id": 14, "name": "\u041a\u0430\u0442\u0435\u0433\u043e\u0440\u0438\u044f", "content": false, "aliases": ["CAT"], "issubject": true, "istalk": false}, "Category talk": {"id": 15, "name": "\u041e\u0431\u0441\u0443\u0436\u0434\u0435\u043d\u0438\u0435 \u043a\u0430\u0442\u0435\u0433\u043e\u0440\u0438\u0438", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Thread": {"id": 90, "name": "Thread", "content": false, "aliases": [], "issubject": true, "istalk": false}, "Thread talk": {"id": 91, "name": "Thread talk", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Summary": {"id": 92, "name": "Summary", "content": false, "aliases": [], "issubject": true, "istalk": false}, "Summary talk": {"id": 93, "name": "Summary talk", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Appendix": {"id": 100, "name": "Appendix", "content": false, "aliases": ["AP"], "issubject": true, "istalk": false}, "Appendix talk": {"id": 101, "name": "Appendix talk", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Concordance": {"id": 102, "name": "Concordance", "content": false, "aliases": [], "issubject": true, "istalk": false}, "Concordance talk": {"id": 103, "name": "Concordance talk", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Index": {"id": 104, "name": "Index", "content": false, "aliases": [], "issubject": true, "istalk": false}, "Index talk": {"id": 105, "name": "Index talk", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Rhymes": {"id": 106, "name": "Rhymes", "content": false, "aliases": [], "issubject": true, "istalk": false}, "Rhymes talk": {"id": 107, "name": "Rhymes talk", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Transwiki": {"id": 108, "name": "Transwiki", "content": false, "aliases": [], "issubject": true, "istalk": false}, "Transwiki talk": {"id": 109, "name": "Transwiki talk", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Thesaurus": {"id": 110, "name": "Thesaurus", "content": false, "aliases": ["WS", "Wikisaurus"], "issubject": true, "istalk": false}, "Thesaurus talk": {"id": 111, "name": "Thesaurus talk", "content": false, "aliases": ["Wikisaurus talk"], "issubject": false, "istalk": true}, "Citations": {"id": 114, "name": "Citations", "content": false, "aliases": [], "issubject": true, "istalk": false}, "Citations talk": {"id": 115, "name": "Citations talk", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Sign gloss": {"id": 116, "name": "Sign gloss", "content": false, "aliases": [], "issubject": true, "istalk": false}, "Sign gloss talk": {"id": 117, "name": "Sign gloss talk", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Reconstruction": {"id": 118, "name": "Reconstruction", "content": false, "aliases": ["RC"], "issubject": true, "istalk": false}, "Reconstruction talk": {"id": 119, "name": "Reconstruction talk", "content": false, "aliases": [], "issubject": false, "istalk": true}, "TimedText": {"id": 710, "name": "TimedText", "content": false, "aliases": [], "issubject": true, "istalk": false}, "TimedText talk": {"id": 711, "name": "TimedText talk", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Module": {"id": 828, "name": "\u041c\u043e\u0434\u0443\u043b\u044c", "content": false, "aliases": ["MOD"], "issubject": true, "istalk": false}, "Module talk": {"id": 829, "name": "\u041e\u0431\u0441\u0443\u0436\u0434\u0435\u043d\u0438\u0435 \u043c\u043e\u0434\u0443\u043b\u044f", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Gadget": {"id": 2300, "name": "Gadget", "content": false, "aliases": [], "issubject": true, "istalk": false}, "Gadget talk": {"id": 2301, "name": "Gadget talk", "content": false, "aliases": [], "issubject": false, "istalk": true}, "Gadget definition": {"id": 2302, "name": "Gadget definition", "content": false, "aliases": [], "issubject": true, "istalk": false}, "Gadget definition talk": {"id": 2303, "name": "Gadget definition talk", "content": false, "aliases": [], "issubject": false, "istalk": true}}
+{
+  "Media": {
+    "id": -2,
+    "name": "Медиа",
+    "content": false,
+    "aliases": [],
+    "issubject": true,
+    "istalk": false
+  },
+  "Special": {
+    "id": -1,
+    "name": "Служебная",
+    "content": false,
+    "aliases": [],
+    "issubject": true,
+    "istalk": false
+  },
+  "Main": {
+    "id": 0,
+    "name": "Main",
+    "content": true,
+    "aliases": [],
+    "issubject": true,
+    "istalk": false
+  },
+  "Talk": {
+    "id": 1,
+    "name": "Обсуждение",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "User": {
+    "id": 2,
+    "name": "Участник",
+    "content": false,
+    "aliases": [
+      "U",
+      "У",
+      "Участница"
+    ],
+    "issubject": true,
+    "istalk": false
+  },
+  "User talk": {
+    "id": 3,
+    "name": "Обсуждение участника",
+    "content": false,
+    "aliases": [
+      "UT",
+      "ОУ",
+      "Обсуждение участницы"
+    ],
+    "issubject": false,
+    "istalk": true
+  },
+  "Project": {
+    "id": 4,
+    "name": "Викисловарь",
+    "content": false,
+    "aliases": [
+      "WT",
+      "Wiktionary",
+      "ВС"
+    ],
+    "issubject": true,
+    "istalk": false
+  },
+  "Project talk": {
+    "id": 5,
+    "name": "Обсуждение Викисловаря",
+    "content": false,
+    "aliases": [
+      "Wiktionary talk"
+    ],
+    "issubject": false,
+    "istalk": true
+  },
+  "File": {
+    "id": 6,
+    "name": "Файл",
+    "content": false,
+    "aliases": [
+      "Image",
+      "Изображение"
+    ],
+    "issubject": true,
+    "istalk": false
+  },
+  "File talk": {
+    "id": 7,
+    "name": "Обсуждение файла",
+    "content": false,
+    "aliases": [
+      "Image talk",
+      "Обсуждение изображения"
+    ],
+    "issubject": false,
+    "istalk": true
+  },
+  "MediaWiki": {
+    "id": 8,
+    "name": "MediaWiki",
+    "content": false,
+    "aliases": [],
+    "issubject": true,
+    "istalk": false
+  },
+  "MediaWiki talk": {
+    "id": 9,
+    "name": "Обсуждение MediaWiki",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "Template": {
+    "id": 10,
+    "name": "Шаблон",
+    "content": false,
+    "aliases": [
+      "T",
+      "Ш"
+    ],
+    "issubject": true,
+    "istalk": false
+  },
+  "Template talk": {
+    "id": 11,
+    "name": "Обсуждение шаблона",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "Help": {
+    "id": 12,
+    "name": "Справка",
+    "content": false,
+    "aliases": [],
+    "issubject": true,
+    "istalk": false
+  },
+  "Help talk": {
+    "id": 13,
+    "name": "Обсуждение справки",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "Category": {
+    "id": 14,
+    "name": "Категория",
+    "content": false,
+    "aliases": [
+      "К"
+    ],
+    "issubject": true,
+    "istalk": false
+  },
+  "Category talk": {
+    "id": 15,
+    "name": "Обсуждение категории",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "Приложение": {
+    "id": 100,
+    "name": "Приложение",
+    "content": false,
+    "aliases": [
+      "Appendix"
+    ],
+    "issubject": true,
+    "istalk": false
+  },
+  "Обсуждение приложения": {
+    "id": 101,
+    "name": "Обсуждение приложения",
+    "content": false,
+    "aliases": [
+      "Appendix talk"
+    ],
+    "issubject": false,
+    "istalk": true
+  },
+  "Конкорданс": {
+    "id": 102,
+    "name": "Конкорданс",
+    "content": false,
+    "aliases": [
+      "Concordance"
+    ],
+    "issubject": true,
+    "istalk": false
+  },
+  "Обсуждение конкорданса": {
+    "id": 103,
+    "name": "Обсуждение конкорданса",
+    "content": false,
+    "aliases": [
+      "Concordance talk"
+    ],
+    "issubject": false,
+    "istalk": true
+  },
+  "Индекс": {
+    "id": 104,
+    "name": "Индекс",
+    "content": false,
+    "aliases": [
+      "Index"
+    ],
+    "issubject": true,
+    "istalk": false
+  },
+  "Обсуждение индекса": {
+    "id": 105,
+    "name": "Обсуждение индекса",
+    "content": false,
+    "aliases": [
+      "Index talk"
+    ],
+    "issubject": false,
+    "istalk": true
+  },
+  "Рифмы": {
+    "id": 106,
+    "name": "Рифмы",
+    "content": false,
+    "aliases": [
+      "Rhymes"
+    ],
+    "issubject": true,
+    "istalk": false
+  },
+  "Обсуждение рифм": {
+    "id": 107,
+    "name": "Обсуждение рифм",
+    "content": false,
+    "aliases": [
+      "Rhymes talk"
+    ],
+    "issubject": false,
+    "istalk": true
+  },
+  "TimedText": {
+    "id": 710,
+    "name": "TimedText",
+    "content": false,
+    "aliases": [],
+    "issubject": true,
+    "istalk": false
+  },
+  "TimedText talk": {
+    "id": 711,
+    "name": "TimedText talk",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "Module": {
+    "id": 828,
+    "name": "Модуль",
+    "content": false,
+    "aliases": [
+      "М"
+    ],
+    "issubject": true,
+    "istalk": false
+  },
+  "Module talk": {
+    "id": 829,
+    "name": "Обсуждение модуля",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "Gadget": {
+    "id": 2300,
+    "name": "Гаджет",
+    "content": false,
+    "aliases": [],
+    "issubject": true,
+    "istalk": false
+  },
+  "Gadget talk": {
+    "id": 2301,
+    "name": "Обсуждение гаджета",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "Gadget definition": {
+    "id": 2302,
+    "name": "Определение гаджета",
+    "content": false,
+    "aliases": [],
+    "issubject": true,
+    "istalk": false
+  },
+  "Gadget definition talk": {
+    "id": 2303,
+    "name": "Обсуждение определения гаджета",
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  }
+}

--- a/src/wikitextprocessor/luaexec.py
+++ b/src/wikitextprocessor/luaexec.py
@@ -61,15 +61,17 @@ def lua_loader(ctx: "Wtp", modname: str) -> Optional[str]:
     assert isinstance(modname, str)
     modname = modname.strip()
     ns_data = ctx.NAMESPACE_DATA["Module"]
-    ns_prefix = ns_data["name"] + ":"
-    ns_alias_prefixes = tuple(alias + ":" for alias in ns_data["aliases"])
-    if modname.startswith(ns_alias_prefixes):
-        modname = ns_prefix + modname[modname.find(":") + 1 :]
+    local_ns_prefix = ns_data["name"] + ":"
+    ns_prefixes = tuple(alias + ":" for alias in ns_data["aliases"])
+    if local_ns_prefix != "Module:":
+        ns_prefixes = ns_prefixes + ("Module:",)
+    if modname.startswith(ns_prefixes):
+        modname = local_ns_prefix + modname[modname.find(":") + 1 :]
 
     # Local name usually not used in Lua code
-    if modname.startswith(("Module:", ns_prefix)):
+    if modname.startswith(local_ns_prefix):
         # First try to load it as a module
-        if modname.startswith(("Module:_", ns_prefix + "_")):
+        if modname.startswith(local_ns_prefix + "_"):
             # Module names starting with _ are considered internal and cannot be
             # loaded from the dump file for security reasons.  This is to ensure
             # that the sandbox always gets loaded from a local file.


### PR DESCRIPTION
Fix the Lua module page not found error by replacing namspace prefix. 