### PR TITLE
Fix two wiktextract test errors caused by 02ae183

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -1693,18 +1693,9 @@ class Wtp:
             local_ns_name = self.LOCAL_NS_NAME_BY_ID[namespace_id]
             ns_prefix = local_ns_name + ":"
             if not title.startswith(ns_prefix):
-                ns_prefixes = []
-                for ns_name, ns_data in self.NAMESPACE_DATA.items():
-                    if ns_data["id"] == namespace_id:
-                        ns_prefixes.append(ns_name.lower() + ":")
-                        ns_prefixes.extend(
-                            [
-                                alias.lower() + ":"
-                                for alias in ns_data["aliases"]
-                            ]
-                        )
-                        break
-                if title.lower().startswith(tuple(ns_prefixes)):
+                if title.lower().startswith(
+                    self.namespace_prefixes("Template")
+                ):
                     # replace lower case and alias prefix
                     title = ns_prefix + title[title.index(":") + 1 :]
                 else:
@@ -1924,6 +1915,24 @@ class Wtp:
             post_template_fn=post_template_fn,
             node_handler_fn=node_handler_fn,
         )
+
+    def namespace_prefixes(
+        self, namespace: str, lower: bool = True
+    ) -> tuple[str, ...]:
+        """Based on given namespace name, create a tuple of aliases"""
+        if namespace in self.NAMESPACE_DATA:
+            prefixes = tuple(
+                map(
+                    lambda x: x.lower() + ":" if lower else x + ":",
+                    [self.NAMESPACE_DATA[namespace]["name"]]
+                    + self.NAMESPACE_DATA[namespace]["aliases"],
+                )
+            )
+            if namespace != self.NAMESPACE_DATA[namespace]["name"]:
+                prefixes += (namespace.lower() + ":",)
+            return prefixes
+        else:
+            return ()
 
 
 def is_chinese_subtitle_template(wtp: Wtp, title: str) -> bool:

--- a/src/wikitextprocessor/parser.py
+++ b/src/wikitextprocessor/parser.py
@@ -507,15 +507,16 @@ TemplateParameters = dict[
 
 
 class TemplateNode(WikiNode):
-    def __init__(self, linenum: int):
+    def __init__(self, linenum: int, ns_prefixes: tuple[str, ...]):
         super().__init__(NodeKind.TEMPLATE, linenum)
         self._template_parameters: Optional[TemplateParameters] = None
+        self._ns_prefixes = ns_prefixes
 
     @property
     def template_name(self) -> str:
         if isinstance(self.largs[0][0], str):
             name = self.largs[0][0].strip()
-            if ":" in name:  # remove prefix
+            if name.lower().startswith(self._ns_prefixes):  # remove prefix
                 name = name[name.index(":") + 1 :]
             return name
         else:
@@ -614,7 +615,7 @@ def _parser_push(ctx: "Wtp", kind: NodeKind) -> WikiNode:
     _parser_merge_str_children(ctx)
     node: WikiNode
     if kind == NodeKind.TEMPLATE:
-        node = TemplateNode(ctx.linenum)
+        node = TemplateNode(ctx.linenum, ctx.namespace_prefixes("Template"))
     elif kind == NodeKind.HTML:
         node = HTMLNode(ctx.linenum)
     elif kind in KIND_TO_LEVEL:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2706,6 +2706,23 @@ def foo(x):
         root = self.ctx.parse("[<nowiki/>[link]]")
         self.assertEqual(root.children, ["&lsqb;&lsqb;link&rsqb;&rsqb;"])
 
+    def test_template_node_template_name_prop(self):
+        tests = [
+            ["{{:page_in_main_ns}}", ":page_in_main_ns"],  # transclude page
+            ["{{Template:title}}", "title"],
+            ["{{t:title}}", "title"],  # alias
+            # template name could have ":"
+            # https://en.wiktionary.org/wiki/Template:RQ:Schuster_Hepaticae
+            ["{{RQ:Schuster Hepaticae}}", "RQ:Schuster Hepaticae"],
+        ]
+        self.ctx.start_page("")
+        for wikitext, title in tests:
+            with self.subTest(wikitext=wikitext, title=title):
+                root = self.ctx.parse(wikitext)
+                template_node = root.children[0]
+                self.assertTrue(isinstance(template_node, TemplateNode))
+                self.assertEqual(template_node.template_name, title)
+
 
 # XXX implement <nowiki/> marking for links, templates
 #  - https://en.wikipedia.org/wiki/Help:Wikitext#Nowiki

--- a/tests/test_wikiprocess.py
+++ b/tests/test_wikiprocess.py
@@ -4182,7 +4182,7 @@ return export
         )
         self.assertEqual(self.ctx.expand("{{Foo:bar}}"), "foobar")
 
-    def test_namespace_prefixes(self):
+    def test_get_page_with_namespace_prefixes(self):
         page = Page(
             "Template:title", 10, body="template text", model="wikitext"
         )
@@ -4190,11 +4190,7 @@ return export
         self.assertEqual(self.ctx.get_page("T:title", 10), page)
         self.assertEqual(self.ctx.get_page("t:title", 10), page)
         self.ctx.start_page("")
-        wikitext = "{{t:title}}"
-        self.assertEqual(self.ctx.expand(wikitext), page.body)
-        root = self.ctx.parse(wikitext)
-        template_node = root.children[0]
-        self.assertEqual(template_node.template_name, "title")
+        self.assertEqual(self.ctx.expand("{{t:title}}"), page.body)
 
 
 # XXX Test template_fn


### PR DESCRIPTION
`Wtp.namespace_prefixes` is copied from
`wiktextract.datautils.ns_title_prefix_tuple`.

There are two wiktextract test errors use the
`TemplateNode.template_name` property and the name string is sliced incorrectly from my last commit.