### PR TITLE
Fix: {{{foo|bar}}} should return 'bar' outside template call

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -1577,7 +1577,14 @@ class Wtp:
                     self.expand_stack.pop()  # template name
                     parts.append(t)
                 elif kind == "A":
-                    parts.append(self._unexpanded_arg(args, nowiki))
+                    if nowiki:
+                        parts.append(self._unexpanded_arg(args, nowiki))
+                        continue
+                    self.expand_stack.append("ARGVAL-NO-TEMPLATE")
+                    t = expand_args(ch, {})
+                    self.expand_stack.pop()
+                    parts.append(t)
+                    continue
                 elif kind == "L":
                     if nowiki:
                         parts.append(self._unexpanded_link(args, nowiki))

--- a/tests/test_node_expand.py
+++ b/tests/test_node_expand.py
@@ -118,6 +118,9 @@ class NodeExpTests(unittest.TestCase):
     def test_templatearg3(self):
         self.backcvt("{{{a|}}}", "{{{a|}}}")
 
+    def test_templatearg3a(self):
+        self.backcvt("{{{|a}}}", "{{{|a}}}")
+
     def test_templatearg4(self):
         self.backcvt("{{{{{templ}}}}}", "{{{{{templ}}}}}")
 
@@ -194,6 +197,22 @@ class NodeExpTests(unittest.TestCase):
 
     def test_text5(self):
         self.totext("foo<ref x=1>bar</ref> z", "foo z")
+
+    def test_text6(self):
+        # Undefined "foo"
+        self.totext("{{{foo}}}", "{{{foo}}}")
+
+    def test_text7(self):
+        # default to "foo"
+        self.totext("{{{|foo}}}", "foo")
+
+    def test_text8(self):
+        # default to "foo"
+        self.totext("{{{bar|foo}}}", "foo")
+
+    def test_text9(self):
+        # default to "foo"
+        self.totext("{{{bar|{{{baz|foo}}}}}}", "foo")
 
     @patch(
         "wikitextprocessor.Wtp.get_page",


### PR DESCRIPTION
"Template arguments" (triple-brace constructions like {{{foo}}}, {{{foo|bar}}} and {{{|bar}}}) were previously rendered as text when they were found outside of a template call (ie. they weren't an 'argument').

Wiktionary sandbox will render

```
{{{foo|bar}}}
{{{foo}}}
{{{|baz}}}
{{{foo|{{{bar|baz}}}}}}
```

as `bar {{{foo}}} baz baz`, because even though "foo" is an empty variable, the defaults should still render, and the empty variable on its own should decompose into a string. Previously, all of the above would fallback to decomposing as a string ( {{{foo|bar}}} -> '{{{foo|bar}}}').