### PR TITLE
Pass `include` argument to `mediawiki_langcodes.get_all_names()`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,8 @@ omit = ["tests/*"]
 
 [tool.ruff]
 line-length = 80
+
+[tool.ruff.lint]
 select = [
     "E",  # pycodestyle error
     "F",  # Pyflakes

--- a/src/wikitextprocessor/luaexec.py
+++ b/src/wikitextprocessor/luaexec.py
@@ -231,7 +231,7 @@ def fetch_language_names(
 
     names = {
         lang_code: lang_name
-        for lang_code, lang_name in get_all_names(in_language)
+        for lang_code, lang_name in get_all_names(in_language, include == "")
     }
     return ctx.lua.table_from(names)  # type: ignore[union-attr]
     # ⇑⇑ tells mypy to ignore an 'error';


### PR DESCRIPTION
By default, only language codes defined in MediaWiki's php code are returned from `mw.languages.fetchLanguageNames`(when the `include` argument is not passed).

Previous code of `get_all_names` returns all languages, [v0.2.0](https://github.com/xxyzz/mediawiki_langcodes/releases/tag/v0.2.0) adds the second bool argument to control whether returns MediaWiki defined languages or all languages.

Issue #201