### PR TITLE
Allow `{` before another curly bracket inside template

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -715,7 +715,7 @@ class Wtp:
             # Replace template invocation
             text = re.sub(
                 r"\{" + MAGIC_NOWIKI_CHAR + r"?\{((?:"
-                r"[^{}](?:{[^{}])?|"  # lone possible { and also default "any"
+                r"[^{}]{?|"  # lone possible { and also default "any"
                 r"}(?=[^{}])|"  # lone `}`, (?=...) is not consumed (lookahead)
                 r"-{}-|"  # GitHub issue #59 Chinese wiktionary special `-{}-`
                 r"}{|"  # latex argument: "<math>\frac{1}{2}</math>"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2791,6 +2791,22 @@ def foo(x):
                 self.assertTrue(isinstance(template_node, TemplateNode))
                 self.assertEqual(template_node.template_name, title)
 
+    def test_left_curly_bracket_in_template(self):
+        # https://en.wiktionary.org/wiki/llave
+        # GitHub issue: tatuylonen/wiktextract#499
+        self.ctx.start_page("llave")
+        for wikitext, params in [
+            ("{{m|mul|{}}", {1: "mul", 2: "{"}),
+            ("{{m|mul|{ }}", {1: "mul", 2: "{ "}),
+            ("{{m|mul|} }}", {1: "mul", 2: "} "}),
+        ]:
+            with self.subTest(wikitext=wikitext, params=params):
+                root = self.ctx.parse(wikitext)
+                template = root.children[0]
+                self.assertTrue(isinstance(template, TemplateNode))
+                self.assertEqual(template.template_name, "m")
+                self.assertEqual(template.template_parameters, params)
+
 
 # XXX implement <nowiki/> marking for links, templates
 #  - https://en.wikipedia.org/wiki/Help:Wikitext#Nowiki


### PR DESCRIPTION
Fixes issue tatuylonen/wiktextract#499

Previous regex matches `{{m|mul|{ }}` but not `{{m|mul{}}`.