### PR TITLE
Strip newlines from end template arguments when calling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 # Run "make clean" to remove automatically generated files
 ruff:
 	python -m ruff --diff src/wikitextprocessor
+	python -m ruff --diff tests
 test:
 	python -m unittest discover -b -s tests
 test_coverage:

--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -1270,6 +1270,7 @@ class Wtp:
                     ch = m.group(0)
                     idx = ord(ch) - MAGIC_FIRST
                     kind, args, nowiki = self.cookies[idx]
+                    # print(f"{kind=}, {args=}, {argmap=}")
                     assert isinstance(args, tuple)
                     if nowiki:
                         # If this template/link/arg has <nowiki />, then just
@@ -1279,7 +1280,10 @@ class Wtp:
                     if kind == "T":
                         # Template transclusion or parser function call.
                         # Expand its arguments.
-                        new_args = tuple(expand_args(x, argmap) for x in args)
+                        new_args = tuple(
+                            expand_args(x, argmap).removesuffix("\n")
+                            for x in args
+                        )
                         parts.append(self._save_value(kind, new_args, nowiki))
                         continue
                     if kind == "A":
@@ -1302,7 +1306,7 @@ class Wtp:
                             k = re.sub(r"\s+", " ", k).strip()
                         v = argmap.get(k, None)
                         if v is not None:
-                            parts.append(v)
+                            parts.append(v.removesuffix("\n"))
                             continue
                         if len(args) >= 2:
                             self.expand_stack.append("ARG-DEFVAL")

--- a/src/wikitextprocessor/luaexec.py
+++ b/src/wikitextprocessor/luaexec.py
@@ -412,7 +412,7 @@ def call_lua_sandbox(
         if isinstance(args, dict):
             frame_args = {}
             for k, arg in args.items():
-                arg = re.sub(r"(?si)<\s*noinclude\s*/\s*>", "", arg)
+                arg = re.sub(r"(?si)(<\s*noinclude\s*/\s*>|\n$)", "", arg)
                 frame_args[k] = arg
         else:
             assert isinstance(args, (list, tuple))
@@ -449,7 +449,7 @@ def call_lua_sandbox(
                 # (e.g., Template:cop-fay-conj-table), whereas Lua code
                 # does not always like them (e.g., remove_links() in
                 # Module:links).
-                arg = re.sub(r"(?si)<\s*noinclude\s*/\s*>", "", arg)
+                arg = re.sub(r"(?si)(<\s*noinclude\s*/\s*>|\n$)", "", arg)
                 frame_args[k] = arg
         frame_args_lt: "_LuaTable" = lua.table_from(frame_args)  # type: ignore[union-attr]
 

--- a/tests/test_wikiprocess.py
+++ b/tests/test_wikiprocess.py
@@ -4199,7 +4199,17 @@ return export
         )
         self.assertEqual(self.ctx.get_page("mod:title", 828), module_page)
 
-
+    def test_unnamed_template_arg_end_in_newline(self):
+        # https://ru.wiktionary.org/wiki/adygejski
+        # newline at the end of unnamed template argument should be removed
+        self.ctx.add_page("Template:test", 10, "{{{1}}}")
+        self.ctx.start_page("")
+        self.assertEqual(
+            self.ctx.expand("{{test| \n unnamed1 \n}}"), " \n unnamed1 "
+        )
+        self.assertEqual(
+            self.ctx.expand("{{test| \n {{test|unnamed2}} \n}}"), " \n unnamed2 "
+        )
 # XXX Test template_fn
 
 # XXX test post_template_fn

--- a/tests/test_wikiprocess.py
+++ b/tests/test_wikiprocess.py
@@ -4203,12 +4203,29 @@ return export
         # https://ru.wiktionary.org/wiki/adygejski
         # newline at the end of unnamed template argument should be removed
         self.ctx.add_page("Template:test", 10, "{{{1}}}")
+        self.ctx.add_page("Template:testlua", 10, "{{#invoke:test|test|{{{1}}}}}")
+        self.ctx.add_page(
+            "Module:test",
+            828,
+            """
+            local export = {}
+
+            function export.test(frame)
+              return frame:getParent().args[1] .. "-" .. frame.args[1]
+            end
+
+            return export
+            """,)
         self.ctx.start_page("")
         self.assertEqual(
             self.ctx.expand("{{test| \n unnamed1 \n}}"), " \n unnamed1 "
         )
         self.assertEqual(
-            self.ctx.expand("{{test| \n {{test|unnamed2}} \n}}"), " \n unnamed2 "
+            self.ctx.expand("{{test| \n {{test|unnamed2}} \n}}"),
+            " \n unnamed2 ",
+        )
+        self.assertEqual(
+            self.ctx.expand("{{testlua| \n unnamed3 \n}}"), " \n unnamed3 - \n unnamed3"
         )
 # XXX Test template_fn
 

--- a/tests/test_wikiprocess.py
+++ b/tests/test_wikiprocess.py
@@ -4203,7 +4203,9 @@ return export
         # https://ru.wiktionary.org/wiki/adygejski
         # newline at the end of unnamed template argument should be removed
         self.ctx.add_page("Template:test", 10, "{{{1}}}")
-        self.ctx.add_page("Template:testlua", 10, "{{#invoke:test|test|{{{1}}}}}")
+        self.ctx.add_page(
+            "Template:testlua", 10, "{{#invoke:test|test|{{{1}}}}}"
+        )
         self.ctx.add_page(
             "Module:test",
             828,
@@ -4215,7 +4217,8 @@ return export
             end
 
             return export
-            """,)
+            """,
+        )
         self.ctx.start_page("")
         self.assertEqual(
             self.ctx.expand("{{test| \n unnamed1 \n}}"), " \n unnamed1 "
@@ -4225,8 +4228,11 @@ return export
             " \n unnamed2 ",
         )
         self.assertEqual(
-            self.ctx.expand("{{testlua| \n unnamed3 \n}}"), " \n unnamed3 - \n unnamed3"
+            self.ctx.expand("{{testlua| \n unnamed3 \n}}"),
+            " \n unnamed3 - \n unnamed3 ",
         )
+
+
 # XXX Test template_fn
 
 # XXX test post_template_fn


### PR DESCRIPTION
Should fix #208

This stripping is done at the point of calling because removing the newline when in _encode, for example, removes some data we might want to keep for when we use node_to_wikitext and revert the parse tree back to text. Then the newlines would be gone.

Co-authored by: xxyzz