### PR TITLE
Fix bug in _sandbox_phase2/make_frame/extensionTag

### DIFF
--- a/src/wikitextprocessor/luaexec.py
+++ b/src/wikitextprocessor/luaexec.py
@@ -481,7 +481,7 @@ def call_lua_sandbox(
                 attrs2 = list(
                     v
                     if isinstance(k, int)
-                    else '{}="{}"'.format(k, html.escape(v, quote=True))
+                    else '{}="{}"'.format(k, html.escape(str(v), quote=True))
                     for k, v in sorted(attrs.items(), key=lambda x: str(x[0]))
                 )
             elif not attrs:

--- a/tests/test_wikiprocess.py
+++ b/tests/test_wikiprocess.py
@@ -2590,6 +2590,16 @@ return export
         return frame:extensionTag("not_allowed_tag")""",
         )
 
+    def test_frame_extensionTag6(self):
+        # Sometimes an extensionTag call might return a table of arguments
+        # with values that are not strings; this is a fixed bug
+        self.scribunto(
+            '<ref class="1.4" id="1">some text</ref>',
+            """
+        return frame:extensionTag{name="ref", content="some text",
+        args={class=1.4, id=1}}""",
+        )
+
     def test_frame_newChild1(self):
         self.scribunto(
             "",


### PR DESCRIPTION
`args[0]["args"]` is a full Lua table, which is not necessarily all string values. This caused at least some Lua errors when html.escape assumed `v` was a string; `v.replace()` would panic.