### PR TITLE
Chaining methods in mw.html should probably return self

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -205,6 +205,7 @@ class Wtp:
         "lua_frame_stack",
         "project",  # "wiktionary" or "wikipedia"
         "strip_marker_cache",
+        "ALLOWED_EXTENSION_TAGS",
     )
 
     def __init__(
@@ -253,6 +254,7 @@ class Wtp:
         self.lua_frame_stack: deque["_LuaTable"] = deque()
         self.project = project
         self.strip_marker_cache: defaultdict[str, int] = defaultdict(int)
+        self.ALLOWED_EXTENSION_TAGS: set[str] = {"nowiki"}
 
     def create_db(self) -> None:
         from .wikidata import init_wikidata_cache

--- a/src/wikitextprocessor/lua/mw_html.lua
+++ b/src/wikitextprocessor/lua/mw_html.lua
@@ -152,11 +152,11 @@ function Html:getAttr(name)
 end
 
 function Html:addClass(new_class)
-   if new_class == nil then return end
+   if new_class == nil then return self end
    local classes = self:getAttr("class") or ""
    local new_classes = {}
    for cl in mw.ustring.gmatch(classes, "([^%s]+)") do
-      if cl == new_class then return end
+      if cl == new_class then return self end
    end
    if classes == "" then
       classes = new_class
@@ -174,7 +174,7 @@ function Html:css(name, value)
             self:css(k, v)
          end
       end
-      return
+      return self
    end
    self._css[name] = value
    return self

--- a/src/wikitextprocessor/parserfns.py
+++ b/src/wikitextprocessor/parserfns.py
@@ -184,7 +184,7 @@ def tag_fn(
 ) -> str:
     """Implements #tag parser function."""
     tag = expander(args[0]).lower() if args else ""
-    if tag not in ALLOWED_HTML_TAGS and tag != "nowiki":
+    if tag not in ALLOWED_HTML_TAGS and tag not in ctx.ALLOWED_EXTENSION_TAGS:
         ctx.warning(
             "#tag creating non-allowed tag <{}> - omitted".format(tag),
             sortid="parserfns/156",

--- a/src/wikitextprocessor/wikihtml.py
+++ b/src/wikitextprocessor/wikihtml.py
@@ -85,9 +85,11 @@ ALLOWED_HTML_TAGS: dict[str, HTMLTagData] = {
     "includeonly": {"parents": ["*"], "content": ["*"]},
     # From InputBox extension, see
     # https://www.mediawiki.org/wiki/Extension:InputBox
+    "indicator": {"parents": ["phrasing"], "content": ["phrasing"]},
     "inputbox": {"parents": ["phrasing"], "content": ["phrasing"]},
     "ins": {"parents": ["phrasing"], "content": ["phrasing"]},
     "kbd": {"parents": ["phrasing"], "content": ["phrasing"]},
+    "langconvert": {"parents": ["phrasing"], "content": ["phrasing"]},
     "li": {
         "parents": ["ul", "ol", "menu"],
         "close-next": ["li"],

--- a/tests/test_wikiprocess.py
+++ b/tests/test_wikiprocess.py
@@ -3123,6 +3123,17 @@ return export
         return tostring(t)""",
         )
 
+    def test_mw_html11b(self):
+        self.scribunto(
+            '<div class="bar foo"></div>',
+            """
+        local t = mw.html.create("div")
+        t:addClass("bar")
+        :addClass()
+        :addClass("foo")
+        return tostring(t)""",
+        )
+
     def test_mw_html12(self):
         self.scribunto(
             '<div style="foo:bar;"></div>',
@@ -3139,6 +3150,17 @@ return export
         local t = mw.html.create("div")
         t:cssText("foo:bar;")
         t:cssText("width:300px")
+        return tostring(t)""",
+        )
+
+    def test_mw_html13b(self):
+        self.scribunto(
+            '<div style="foo:bar;width:300px;"></div>',
+            """
+        local t = mw.html.create("div")
+        t:cssText("foo:bar;")
+        :cssText()
+        :cssText("width:300px")
         return tostring(t)""",
         )
 
@@ -3216,6 +3238,16 @@ return export
             """
         local t = mw.html.create("div")
         t:css("foo", "bar")
+        return tostring(t)""",
+        )
+
+    def test_mw_html22(self):
+        self.scribunto(
+            "<span></span>",
+            """
+        local t = mw.html.create('span')
+        :addClass( nil  )
+        :wikitext( nil )
         return tostring(t)""",
         )
 


### PR DESCRIPTION
Fix this bug:

```lua
		local htmlTitle = mw.html.create('span')
			:attr{ id = 'coordinates' }
			:addClass( displayinline and 'noprint' or nil )
			:wikitext( "" )
```

Our implementation would break after :addClass because it would return nil, when it should have returned `self`, so that :wikitext() would not try to 'index' a nil value. Even if the mw.html method doesn't succeed, it should return `self` for this chaining; I checked the scribunto source, and none of the methods returned without returning something or `self`.