### PR TITLE
Move HTML tag data to Wtp context instead of global

### DIFF
--- a/src/wikitextprocessor/node_expand.py
+++ b/src/wikitextprocessor/node_expand.py
@@ -176,6 +176,9 @@ def to_wikitext(
                 if node.attrs:
                     parts.append(" ")
                     parts.append(to_attrs(node))
+                # We're using ALLOWED_HTML_TAGS here because we don't have
+                # ctx.allowed_html_tags in this function, and it doesn't
+                # *really* matter if there's an extract / at the end.
                 if ALLOWED_HTML_TAGS.get(node.sarg, {"no-end-tag": True}).get(
                     "no-end-tag"
                 ):

--- a/src/wikitextprocessor/parserfns.py
+++ b/src/wikitextprocessor/parserfns.py
@@ -14,7 +14,6 @@ import dateparser
 
 from .common import MAGIC_NOWIKI_CHAR, add_newline_to_expansion, nowiki_quote
 from .interwiki import get_interwiki_map
-from .wikihtml import ALLOWED_HTML_TAGS
 
 if TYPE_CHECKING:
     # Reached only by mypy or other type-checker
@@ -184,7 +183,7 @@ def tag_fn(
 ) -> str:
     """Implements #tag parser function."""
     tag = expander(args[0]).lower() if args else ""
-    if tag not in ALLOWED_HTML_TAGS and tag not in ctx.ALLOWED_EXTENSION_TAGS:
+    if tag not in ctx.allowed_html_tags and tag != "nowiki":
         ctx.warning(
             "#tag creating non-allowed tag <{}> - omitted".format(tag),
             sortid="parserfns/156",

--- a/src/wikitextprocessor/parserfns.py
+++ b/src/wikitextprocessor/parserfns.py
@@ -1397,9 +1397,11 @@ def coordinates_fn(
 ) -> str:
     # According to the GeoData (not Maps) #coordinate parser function source
     # code, #coordinates only returns an empty string or an error string.
-    # https://github.com/wikimedia/mediawiki-extensions-GeoData/blob/c025f10fd88d1d72655bc43599071c4dddaab1f8/includes/CoordinatesParserFunction.php#L42
+    # https://github.com/wikimedia/
+    # mediawiki-extensions-GeoData/blob/
+    # c025f10fd88d1d72655bc43599071c4dddaab1f8/
+    # includes/CoordinatesParserFunction.php#L42
     return ""
-
 
 
 # This list should include names of predefined parser functions and

--- a/src/wikitextprocessor/parserfns.py
+++ b/src/wikitextprocessor/parserfns.py
@@ -1392,6 +1392,16 @@ def current_timestamp_fn(
     return datetime.now().strftime(MEDIAWIKI_TIMESTAMP_FORMAT)
 
 
+def coordinates_fn(
+    wtp: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
+) -> str:
+    # According to the GeoData (not Maps) #coordinate parser function source
+    # code, #coordinates only returns an empty string or an error string.
+    # https://github.com/wikimedia/mediawiki-extensions-GeoData/blob/c025f10fd88d1d72655bc43599071c4dddaab1f8/includes/CoordinatesParserFunction.php#L42
+    return ""
+
+
+
 # This list should include names of predefined parser functions and
 # predefined variables (some of which can take arguments using the same
 # syntax as parser functions and we treat them as parser functions).
@@ -1513,7 +1523,7 @@ PARSER_FUNCTIONS = {
     "#switch": switch_fn,
     "#babel": unimplemented_fn,
     "#categorytree": (categorytree_fn, True),  # This takes kwargs
-    "#coordinates": unimplemented_fn,
+    "#coordinates": coordinates_fn,
     "#invoke": unimplemented_fn,
     "#lst": lst_fn,
     "#lsth": unimplemented_fn,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2816,6 +2816,24 @@ def foo(x):
         self.assertTrue(isinstance(string, str))
         self.assertEqual(string, "{{m|mul|{{ }}")
 
+    def test_extension_tags(self):
+        # Extension tags can be arbitrary, but we don't want to allow
+        # just anything inside HTML-tag-like entities, and we also
+        # need some basic data on how the tag is supposed to behave.
+        extension_tags = {
+            "foo": {"parents": ["phrasing"], "content": ["phrasing"]},
+        }
+        self.ctx = Wtp(
+            extension_tags=extension_tags,
+        )
+        self.ctx.start_page("test")
+        root = self.ctx.parse("<foo>bar</foo>")
+        self.assertEqual(len(root.children), 1)
+        e = root.children[0]
+        self.assertEqual(e.kind, NodeKind.HTML)
+        self.assertEqual(len(e.children), 1)
+        self.assertEqual(e.children[0], "bar")
+
 
 # XXX implement <nowiki/> marking for links, templates
 #  - https://en.wikipedia.org/wiki/Help:Wikitext#Nowiki

--- a/tests/test_parserfns.py
+++ b/tests/test_parserfns.py
@@ -18,3 +18,10 @@ class TestParserFunctions(TestCase):
             self.wtp.expand("{{#time:j F Y|20130914013636}}"),
             "14 September 2013",
         )
+
+    def test_coordinates_fn(self) -> None:
+        self.wtp.start_page("Test")
+        self.assertEqual(
+            self.wtp.expand("{{#coordinates|foo|bar|baz}}"),
+            "",
+        )


### PR DESCRIPTION
Because we want to allow parsing HTML-like extension tags, like `<maplink>` data, we need to add them to the HTML tag data we have, but changing ALLOWED_HTML_TAGS and messing around with capitalised globals doesn't seem the way to go.

ALLOWED_HTML_TAGS will stay as the base on which everything is built, but what should be generally used in the future instead is Wtp.allowed_html_tags, which should also include HTMLTagData entries for extra tags.

Because a bunch of other globals rely on ALLOWED_HTML_TAGS, these also need to be brough back inside the context object, generated in Wtp.__init__().

There was one place with ALLOWED_HTML_TAGS left outside of the context, in `to_wikitext` where a parse tree is turned back into text; here, it was used only to check if a lone tag (`<tag>` without an `</tag>` and without children inside the element) should be outputted with a self-closing slash (`<tag />`) or not; in practice, this should not matter.

The code in Wikitextprocessor doesn't *handle* the HTML element, so currently adding capability to parse a `<maplink>` element doesn't function correctly because it outputs the contents when it apparently shouldn't.

The handling of the extension tags should probably be at a higher level than the parser.