### PR TITLE
Implement partial #property parserfn

### DIFF
--- a/src/wikitextprocessor/parserfns.py
+++ b/src/wikitextprocessor/parserfns.py
@@ -1359,6 +1359,17 @@ def statements_fn(
     wtp: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
     # https://www.wikidata.org/wiki/Wikidata:How_to_use_data_on_Wikimedia_projects
+    # XXX? This implementation doesn't implement the fancy things #statements
+    # generates, like links or images
+    return property_fn(wtp, fn_name, args, expander)
+
+
+def property_fn(
+    wtp: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
+) -> str:
+    # #property is meant to be for pulling bare bones data, I guess.
+    # Does not pull correct data, for example coordinates
+
     from .wikidata import statement_query
 
     prop = ""
@@ -1530,7 +1541,7 @@ PARSER_FUNCTIONS = {
     "#lst": lst_fn,
     "#lsth": unimplemented_fn,
     "#lstx": unimplemented_fn,
-    "#property": unimplemented_fn,
+    "#property": property_fn,
     "#related": unimplemented_fn,
     "#statements": statements_fn,
     "#target": unimplemented_fn,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2020-2022 Tatu Ylonen.  See file LICENSE and https://ylonen.org
 
 import unittest
-from unittest.mock import patch
 
 from wikitextprocessor import Wtp
 from wikitextprocessor.parser import (
@@ -2539,60 +2538,6 @@ def foo(x):
         self.assertTrue(isinstance(html_node, HTMLNode))
         self.assertEqual(html_node.tag, "th")
         self.assertEqual(html_node.attrs, {"colspan": "2"})
-
-    @patch(
-        "wikitextprocessor.wikidata.query_wikidata",
-        return_value={
-            "valueLabel": {"type": "literal", "value": "Douglas Noël Adams"},
-            "itemLabel": {
-                "xml:lang": "en",
-                "type": "literal",
-                "value": "Douglas Adams",
-            },
-            "itemDescription": {
-                "xml:lang": "en",
-                "type": "literal",
-                "value": "English author and humourist (1952–2001)",
-            },
-            "propLabel": {
-                "xml:lang": "en",
-                "type": "literal",
-                "value": "birth name",
-            },
-        },
-    )
-    def test_statements_parser_func(self, mock_f):
-        self.ctx.start_page("Don't panic")
-        expanded = self.ctx.expand("{{#statements:P1477|from=Q42}}")
-        self.assertEqual(expanded, "Douglas Noël Adams")
-        expanded = self.ctx.expand("{{#statements:birth name|from=Q42}}")
-        self.assertEqual(expanded, "Douglas Noël Adams")
-        # Template: https://en.wiktionary.org/wiki/Template:R:ru:STsSRJa
-        # page: https://en.wiktionary.org/wiki/резвиться
-        expanded = self.ctx.expand(
-            "{{#statements:birth name|from={{#if: true| Q42}}}}"
-        )
-        self.assertEqual(expanded, "Douglas Noël Adams")
-        mock_f.assert_called_once()  # use db cache
-
-    @patch(
-        "wikitextprocessor.wikidata.query_wikidata",
-        return_value={
-            "valueLabel": {"type": "literal", "value": "1868-01-01T00:00:00Z"},
-            "itemLabel": {"type": "literal", "value": "Q114098115"},
-            "propLabel": {
-                "xml:lang": "en",
-                "type": "literal",
-                "value": "publication date",
-            },
-        },
-    )
-    def test_statements_publication_date(self, mock_f):
-        # https://en.wiktionary.org/wiki/расплавить
-        # https://en.wiktionary.org/wiki/Template:R:ru:fr:Ganot1868
-        self.ctx.start_page("расплавить")
-        expanded = self.ctx.expand("{{#statements:P577|from=Q114098115}}")
-        self.assertEqual(expanded, "1868")
 
     def test_inverse_order_template_numbered_parameter(self):
         # https://en.wiktionary.org/wiki/落葉歸根

--- a/tests/test_parserfns.py
+++ b/tests/test_parserfns.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+from unittest.mock import patch
 
 
 class TestParserFunctions(TestCase):
@@ -25,3 +26,87 @@ class TestParserFunctions(TestCase):
             self.wtp.expand("{{#coordinates|foo|bar|baz}}"),
             "",
         )
+
+    @patch(
+        "wikitextprocessor.wikidata.query_wikidata",
+        return_value={
+            "value": {"type": "literal", "value": "Douglas Noël Adams"},
+            "itemLabel": {
+                "xml:lang": "en",
+                "type": "literal",
+                "value": "Douglas Adams",
+            },
+            "itemDescription": {
+                "xml:lang": "en",
+                "type": "literal",
+                "value": "English author and humourist (1952–2001)",
+            },
+            "propLabel": {
+                "xml:lang": "en",
+                "type": "literal",
+                "value": "birth name",
+            },
+        },
+    )
+    def test_statements_parser_func(self, mock_query):
+        self.wtp.start_page("Don't panic")
+        expanded = self.wtp.expand("{{#statements:P1477|from=Q42}}")
+        self.assertEqual(expanded, "Douglas Noël Adams")
+        expanded = self.wtp.expand("{{#statements:birth name|from=Q42}}")
+        self.assertEqual(expanded, "Douglas Noël Adams")
+        # Template: https://en.wiktionary.org/wiki/Template:R:ru:STsSRJa
+        # page: https://en.wiktionary.org/wiki/резвиться
+        expanded = self.wtp.expand(
+            "{{#statements:birth name|from={{#if: true| Q42}}}}"
+        )
+        self.assertEqual(expanded, "Douglas Noël Adams")
+        mock_query.assert_called_once()  # use db cache
+
+    @patch(
+        "wikitextprocessor.wikidata.query_wikidata",
+        return_value={
+            "value": {
+                "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+                "type": "literal",
+                "value": "1868-01-01T00:00:00Z",
+            },
+            "itemLabel": {"type": "literal", "value": "Q114098115"},
+            "propLabel": {
+                "xml:lang": "en",
+                "type": "literal",
+                "value": "publication date",
+            },
+        },
+    )
+    def test_statements_publication_date(self, mock_query):
+        # https://en.wiktionary.org/wiki/расплавить
+        # https://en.wiktionary.org/wiki/Template:R:ru:fr:Ganot1868
+        self.wtp.start_page("расплавить")
+        expanded = self.wtp.expand("{{#statements:P577|from=Q114098115}}")
+        self.assertEqual(expanded, "1868")
+
+    @patch(
+        "wikitextprocessor.wikidata.query_wikidata",
+        return_value={
+            "valueLabel": {"type": "literal", "value": "1868-01-01T00:00:00Z"},
+            "itemLabel": {"type": "literal", "value": "Douglas Adams"},
+            "itemDescription": {
+                "type": "literal",
+                "value": "English author and humourist (1952–2001)",
+            },
+            "p": {
+                "type": "uri",
+                "value": "http://www.wikidata.org/entity/P569",
+            },
+            "value": {
+                "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+                "type": "literal",
+                "value": "1952-03-11T00:00:00Z",
+            },
+        },
+    )
+    def test_statements_date(self, mock_query):
+        # https://www.wikidata.org/wiki/Wikidata:How_to_use_data_on_Wikimedia_projects
+        self.wtp.start_page("")
+        expanded = self.wtp.expand("{{#statements:date of birth|from=Q42}}")
+        self.assertEqual(expanded, "11 March 1952")


### PR DESCRIPTION
Currently, #statements return some raw data without processing happening, which is what we would want
.#property to be, although #property also changes the data.

For example, coordinates are formatted, and should not be in the form 'Point(2.294479 48.858296)'.

We might need to implement all of these if we want to be 'correct'...

This commit just takes the code from #statements, puts it in .#property where it fits 'better' and then has #statements called property_fn; same output of 'raw' data, which is hopefully good enough for most purposes.