### PR TITLE
Allow slash in HTML attribute value

### DIFF
--- a/src/wikitextprocessor/parser.py
+++ b/src/wikitextprocessor/parser.py
@@ -1812,7 +1812,7 @@ def tag_fn(ctx: "Wtp", token: str) -> None:
     # Try to parse it as a start tag
     m = re.match(
         r"""<([-a-zA-Z0-9]+)\s*((\b[-a-zA-Z0-9:]+(\s*=\s*("[^"]*"|"""
-        r"""'[^']*'|[^ \t\n"'`=<>]*))?\s*)*)(/?)\s*>""",
+        r"""'[^']*'|[^ \t\n"'`=<>]*))?\s*)*)(/?)>""",
         token,
     )
     if m:

--- a/src/wikitextprocessor/parser.py
+++ b/src/wikitextprocessor/parser.py
@@ -1812,7 +1812,7 @@ def tag_fn(ctx: "Wtp", token: str) -> None:
     # Try to parse it as a start tag
     m = re.match(
         r"""<([-a-zA-Z0-9]+)\s*((\b[-a-zA-Z0-9:]+(\s*=\s*("[^"]*"|"""
-        r"""'[^']*'|[^ \t\n"'`=<>/]*))?\s*)*)(/?)\s*>""",
+        r"""'[^']*'|[^ \t\n"'`=<>]*))?\s*)*)(/?)\s*>""",
         token,
     )
     if m:
@@ -1919,8 +1919,7 @@ def tag_fn(ctx: "Wtp", token: str) -> None:
     else:
         m = re.match(r"</([-a-zA-Z0-9]+)\s*>", token)
         if m is None:
-            print("Could not match end tag token: {!r}".format(token))
-            assert False
+            raise Exception("Could not match end tag token: {!r}".format(token))
         name = m.group(1)
         name = name.lower()
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2834,6 +2834,14 @@ def foo(x):
         self.assertEqual(len(e.children), 1)
         self.assertEqual(e.children[0], "bar")
 
+    def test_slash_in_html_attr_value(self):
+        # https://de.wiktionary.org/wiki/axitiosus
+        self.ctx.start_page("axitiosus")
+        root = self.ctx.parse("<ref name=Ernout/Meillte>{{template}}</ref>")
+        ref_node = root.children[0]
+        self.assertIsInstance(ref_node, HTMLNode)
+        self.assertEqual(ref_node.tag, "ref")
+
 
 # XXX implement <nowiki/> marking for links, templates
 #  - https://en.wikipedia.org/wiki/Help:Wikitext#Nowiki

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2823,9 +2823,7 @@ def foo(x):
         extension_tags = {
             "foo": {"parents": ["phrasing"], "content": ["phrasing"]},
         }
-        self.ctx = Wtp(
-            extension_tags=extension_tags,
-        )
+        self.ctx.allowed_html_tags.update(extension_tags)
         self.ctx.start_page("test")
         root = self.ctx.parse("<foo>bar</foo>")
         self.assertEqual(len(root.children), 1)


### PR DESCRIPTION
Fix parse exception page de edition page "axitiosus", and use `raise Exception` so the `token` variable value could be included in the error message.

Error page: https://kaikki.org/dewiktionary/errors/details-----EXCEPTION-while-parsing-page--axit-Ob46aw13.html