### PR TITLE
Changes to parser regex

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -157,7 +157,7 @@ class BegLineDisableManager:
             self.ctx.begline_enabled = True
 
 
-links = (
+LINKS = (
     # `[[something<abcd>]]`
     # XXX this regex seems to be too complex,
     # could you replace it with just [^][{}]*?
@@ -172,15 +172,15 @@ links = (
     + r"?\]"
 )
 
-links_re = re.compile(links)
+LINKS_RE = re.compile(LINKS)
 
 # Encode external links: [something]
-external_links = r"\[([^][{}<>|\n]+)\]"
+EXTERNAL_LINKS = r"\[([^][{}<>|\n]+)\]"
 
-external_links_re = re.compile(external_links)
+EXTERNAL_LINKS_RE = re.compile(EXTERNAL_LINKS)
 
 # Encode template arguments: {{{arg}}}, {{{..{|..|}..}}}
-template_arguments = (
+TEMPLATE_ARGUMENTS = (
     r"\{"
     + MAGIC_NOWIKI_CHAR
     + r"?\{"
@@ -195,9 +195,9 @@ template_arguments = (
     + r"?\}"
 )
 
-template_arguments_re = re.compile(template_arguments)
+TEMPLATE_ARGUMENTS_RE = re.compile(TEMPLATE_ARGUMENTS)
 
-templates = (
+TEMPLATES = (
     r"\{" + MAGIC_NOWIKI_CHAR + r"?\{((?:"
     r"[^{}]{?|"  # lone possible { and also default "any"
     r"}(?=[^{}])|"  # lone `}`, (?=...) is not consumed (lookahead)
@@ -206,11 +206,11 @@ templates = (
     r")+?)\}" + MAGIC_NOWIKI_CHAR + r"?\}"
 )
 
-templates_re = re.compile(templates)
+TEMPLATES_RE = re.compile(TEMPLATES)
 
-all_brackets_re = re.compile(
+ALL_BRACKETS_RE = re.compile(
     r"("
-    + r"|".join((links, external_links, template_arguments, templates))
+    + r"|".join((LINKS, EXTERNAL_LINKS, TEMPLATE_ARGUMENTS, TEMPLATES))
     + r")"
 )
 
@@ -686,7 +686,7 @@ class Wtp:
             m2 = re.search(
                 # check to see if link contains something that should be
                 # handled first
-                all_brackets_re,
+                ALL_BRACKETS_RE,
                 m.group(0)[2:-2],
             )
             if m2:
@@ -736,7 +736,7 @@ class Wtp:
                 # Encode links.
                 while True:
                     text = re.sub(
-                        links_re,
+                        LINKS_RE,
                         repl_link,
                         text,
                     )
@@ -744,10 +744,10 @@ class Wtp:
                         break
                     prev2 = text
                 # Encode external links: [something]
-                text = re.sub(external_links_re, repl_extlink, text)
+                text = re.sub(EXTERNAL_LINKS_RE, repl_extlink, text)
                 # Encode template arguments: {{{arg}}}, {{{..{|..|}..}}}
                 text = re.sub(
-                    template_arguments_re,
+                    TEMPLATE_ARGUMENTS_RE,
                     repl_arg,
                     text,
                 )
@@ -779,7 +779,7 @@ class Wtp:
                     break
             # Replace template invocation
             text = re.sub(
-                templates_re,
+                TEMPLATES_RE,
                 repl_templ,
                 text,
             )

--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -157,6 +157,64 @@ class BegLineDisableManager:
             self.ctx.begline_enabled = True
 
 
+links = (
+    # `[[something<abcd>]]`
+    # XXX this regex seems to be too complex,
+    # could you replace it with just [^][{}]*?
+    r"\["
+    + MAGIC_NOWIKI_CHAR
+    + r"?\[("
+    # I spent a lot of willpower on this monstrosity.
+    + r"((?!\]\])[^[\n])*(?!\[[\n]+\])((?!\[\[)[^]\n])+"
+    #   ( no ]] ) ( no [ ) ( no [...] )( no [[) (no ]) 
+    + r")\]"
+    + MAGIC_NOWIKI_CHAR
+    + r"?\]"
+)
+
+links_re = re.compile(links)
+
+# Encode external links: [something]
+external_links = r"\[([^][{}<>|\n]+)\]"
+
+external_links_re = re.compile(external_links)
+
+# Encode template arguments: {{{arg}}}, {{{..{|..|}..}}}
+template_arguments = (
+    r"\{"
+    + MAGIC_NOWIKI_CHAR
+    + r"?\{"
+    + MAGIC_NOWIKI_CHAR
+    + r"?\{(("
+    + r"[^{}]|"  # No curly brackets (except inside cookies)
+    + r"\{\|[^{}]*\|\}"  # Outermost table brackets accepted?
+    + r")*?)\}"
+    + MAGIC_NOWIKI_CHAR
+    + r"?\}"
+    + MAGIC_NOWIKI_CHAR
+    + r"?\}"
+)
+
+template_arguments_re = re.compile(template_arguments)
+
+templates = (
+    r"\{" + MAGIC_NOWIKI_CHAR + r"?\{((?:"
+    r"[^{}]{?|"  # lone possible { and also default "any"
+    r"}(?=[^{}])|"  # lone `}`, (?=...) is not consumed (lookahead)
+    r"-{}-|"  # GitHub issue #59 Chinese wiktionary special `-{}-`
+    r"}{|"  # latex argument: "<math>\frac{1}{2}</math>"
+    r")+?)\}" + MAGIC_NOWIKI_CHAR + r"?\}"
+)
+
+templates_re = re.compile(templates)
+
+all_brackets_re = re.compile(
+    r"("
+    + r"|".join((links, external_links, template_arguments, templates))
+    + r")"
+)
+
+
 class Wtp:
     """Context used for processing wikitext and for expanding templates,
     parser functions and Lua macros.  The intended usage pattern is to
@@ -625,6 +683,15 @@ class Wtp:
 
         def repl_link(m: re.Match) -> CookieChar:
             """Replacement function for links [[...]]."""
+            m2 = re.search(
+                # check to see if link contains something that should be
+                # handled first
+                all_brackets_re,
+                m.group(0)[2:-2],
+            )
+            if m2:
+                # print(f"{m.group(0)=}, {m.group(0)=}")
+                return m.group(0)
             nowiki = MAGIC_NOWIKI_CHAR in m.group(0)
             orig = m.group(1)
             if MAGIC_NOWIKI_CHAR in orig:
@@ -669,16 +736,7 @@ class Wtp:
                 # Encode links.
                 while True:
                     text = re.sub(
-                        # `[[something<abcd>]]`
-                        # XXX this regex seems to be too complex,
-                        # could you replace it with just [^][{}]*?
-                        r"\["
-                        + MAGIC_NOWIKI_CHAR
-                        + r"?\[("
-                        + r"[^][{}]+"  # any one char except brackets
-                        + r")\]"
-                        + MAGIC_NOWIKI_CHAR
-                        + r"?\]",
+                        links_re,
                         repl_link,
                         text,
                     )
@@ -686,21 +744,10 @@ class Wtp:
                         break
                     prev2 = text
                 # Encode external links: [something]
-                text = re.sub(r"\[([^][{}<>|\n]+)\]", repl_extlink, text)
+                text = re.sub(external_links_re, repl_extlink, text)
                 # Encode template arguments: {{{arg}}}, {{{..{|..|}..}}}
                 text = re.sub(
-                    r"\{"
-                    + MAGIC_NOWIKI_CHAR
-                    + r"?\{"
-                    + MAGIC_NOWIKI_CHAR
-                    + r"?\{(("
-                    + r"[^{}]|"  # No curly brackets (except inside cookies)
-                    + r"\{\|[^{}]*\|\}"  # Outermost table brackets accepted?
-                    + r")*?)\}"
-                    + MAGIC_NOWIKI_CHAR
-                    + r"?\}"
-                    + MAGIC_NOWIKI_CHAR
-                    + r"?\}",
+                    template_arguments_re,
                     repl_arg,
                     text,
                 )
@@ -732,12 +779,7 @@ class Wtp:
                     break
             # Replace template invocation
             text = re.sub(
-                r"\{" + MAGIC_NOWIKI_CHAR + r"?\{((?:"
-                r"[^{}]{?|"  # lone possible { and also default "any"
-                r"}(?=[^{}])|"  # lone `}`, (?=...) is not consumed (lookahead)
-                r"-{}-|"  # GitHub issue #59 Chinese wiktionary special `-{}-`
-                r"}{|"  # latex argument: "<math>\frac{1}{2}</math>"
-                r")+?)\}" + MAGIC_NOWIKI_CHAR + r"?\}",
+                templates_re,
                 repl_templ,
                 text,
             )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1059,6 +1059,42 @@ dasfasddasfdas
         b = a.largs[0][-1]
         self.assertEqual(b.kind, NodeKind.LINK)
 
+    def test_link7(self):
+        tree = self.parse("test", "[[foo|bar}}}]]")
+        link = tree.children[0]
+        self.assertEqual(link.kind, NodeKind.LINK)
+        self.assertEqual(link.largs, [["foo"], ["bar}}}"]])
+
+    def test_link8(self):
+        tree = self.parse("test", "[[foo| bar] ]]")
+        # print_tree(tree)
+        link = tree.children[0]
+        self.assertEqual(link.kind, NodeKind.LINK)
+        self.assertEqual(link.largs, [["foo"], [" bar] "]])
+
+    def test_link9(self):
+        tree = self.parse("test", "[[foo| [bar]]")
+        # print_tree(tree)
+        link = tree.children[0]
+        self.assertEqual(link.kind, NodeKind.LINK)
+        self.assertEqual(link.largs, [["foo"], [" [bar"]])
+
+    def test_link10(self):
+        tree = self.parse("test", "[[foo| [bar] ]]")
+        # print_tree(tree)
+        link = tree.children[0]
+        self.assertEqual(link.kind, NodeKind.LINK)
+        self.assertEqual(link.largs, [["foo"], [" [bar] "]])
+
+    # def test_link11(self):
+    # I can't get this to work. Our parser is too different from how
+    # wikimedia does it.
+    #     tree = self.parse("test", "[[foo| [bar]]]")
+    #     print_tree(tree)
+    #     link = tree.children[0]
+    #     self.assertEqual(link.kind, NodeKind.LINK)
+    #     self.assertEqual(link.largs, [["foo"], [" [bar]"]])
+
     def test_link_trailing(self):
         tree = self.parse("test", "[[Help]]ing heal")
         self.assertEqual(len(tree.children), 2)
@@ -1575,6 +1611,17 @@ def foo(x):
         self.assertEqual(tt.kind, NodeKind.TEMPLATE_ARG)
         self.assertEqual(tt.largs, [["1"], []])
         self.assertEqual(tt.children, [])
+
+    # def test_templatevar6(self):
+    # This is difficult to test in sandbox mode on the Wiki side, because
+    # there will never be an argument called "foo[" or anything with a
+    # a reserved character...
+    #     tree = self.parse("test", "{{{foo[}}}")
+    #     self.assertEqual(len(tree.children), 1)
+    #     b = tree.children[0]
+    #     self.assertEqual(b.kind, NodeKind.TEMPLATE_ARG)
+    #     self.assertEqual(b.largs, [["foo["]])
+    #     self.assertEqual(b.children, [])
 
     def test_parserfn1(self):
         tree = self.parse("test", "{{CURRENTYEAR}}x")


### PR DESCRIPTION
Partial fix to #225

We can't get 100% correspondence with how Wikimedia parses things because our parser works on different principles, but here's a fix for an edge case. I found a few other edge-cases (added commented-out tests for them) that I don't think we can fix.

The regexes for the parsing-loop in core.py where we turn links, external links, template arguments and templates into magical characters to be stored out of the way while doing inside-out parsing are now outside the function def itself in global space.

The link regex has been changed to accept (in some cases) stray square brackets inside the link itself (but not double brackets or paired brackets).

The link regex also can now contain curly braces, etc. because we handle checking whether the link contains templates etc. in the regex handling function passed into re.sub:

The link substitution function (used to handle the regex matches we come across that match this) has been modified to look for a combination of all the possible regexes that were moved out into global namespace. So if the link regex lets something through (like a template), it will spot it at that point and then returns the original string (which means prev == current, and the loops terminates to handle other stuff instead and returns later to handle the link, if applicable).