### PR TITLE
Implement rudimentary #pagesize parserfn

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -1893,7 +1893,7 @@ class Wtp:
         return page.need_pre_expand
 
     def get_page_resolve_redirect(
-        self, title: str, namespace_id: int
+        self, title: str, namespace_id: Optional[int]
     ) -> Optional[Page]:
         page = self.get_page(title, namespace_id)
         if page is None:
@@ -1902,7 +1902,9 @@ class Wtp:
             return self.get_page(page.redirect_to, namespace_id, True)
         return page
 
-    def get_page_body(self, title: str, namespace_id: int) -> Optional[str]:
+    def get_page_body(
+        self, title: str, namespace_id: Optional[int]
+    ) -> Optional[str]:
         page = self.get_page_resolve_redirect(title, namespace_id)
         return None if page is None else page.body
 

--- a/src/wikitextprocessor/parserfns.py
+++ b/src/wikitextprocessor/parserfns.py
@@ -1426,7 +1426,7 @@ def pagesize_fn(
     if not args:
         return '<strong class="error">No arguments given to #pagesize</strong>'
     page_name = args[0]
-    comma_formatting = not args[1].strip() == "R" if len(args) >= 2 else True
+    comma_formatting = args[1].strip() == "R" if len(args) >= 2 else False
 
     # XXX When the Sqlite library supports octet_length(), change this to
     # SELECT octet_length(body) instead.

--- a/tests/test_parserfns.py
+++ b/tests/test_parserfns.py
@@ -28,8 +28,8 @@ class TestParserFunctions(TestCase):
         )
 
     def test_pagesize_fn(self) -> None:
-        self.wtp.add_page("sizetestA", 0, body="AAAAAAA"*1000)
-        self.wtp.add_page("sizetestB", 0, body="ÄÄÄÄÄÄÄ"*1000)
+        self.wtp.add_page("sizetestA", 0, body="AAAAAAA" * 1000)
+        self.wtp.add_page("sizetestB", 0, body="ÄÄÄÄÄÄÄ" * 1000)
         self.wtp.start_page("Test")
         self.assertEqual(
             self.wtp.expand("{{PAGESIZE:sizetestA|R}}"),

--- a/tests/test_parserfns.py
+++ b/tests/test_parserfns.py
@@ -27,6 +27,27 @@ class TestParserFunctions(TestCase):
             "",
         )
 
+    def test_pagesize_fn(self) -> None:
+        self.wtp.add_page("sizetestA", 0, body="AAAAAAA"*1000)
+        self.wtp.add_page("sizetestB", 0, body="ÄÄÄÄÄÄÄ"*1000)
+        self.wtp.start_page("Test")
+        self.assertEqual(
+            self.wtp.expand("{{PAGESIZE:sizetestA|R}}"),
+            "7,000",
+        )
+        self.assertEqual(
+            self.wtp.expand("{{PAGESIZE:sizetestB|R}}"),
+            "14,000",
+        )
+        self.assertEqual(
+            self.wtp.expand("{{PAGESIZE:sizetestA}}"),
+            "7000",
+        )
+        self.assertEqual(
+            self.wtp.expand("{{PAGESIZE:sizetestB}}"),
+            "14000",
+        )
+
     @patch(
         "wikitextprocessor.wikidata.query_wikidata",
         return_value={


### PR DESCRIPTION
Rarely used, but still needed for things not to break.

Implemented with a simple Sqlite query to get length of page body. #pagesize should return bytesize, not number of characters (depends on encoding), so to be correct we cast body as a blob which now returns bytesize.

The Sqlite version on our machines is old enough
(a couple of years) that it doesn't implement
octet_length(), which would do this without any casting.

XXX: refactor the "name conversion + ->  namespace_id" code in get_page into its own function; this implementation of `#pagesize` returns the size of the first hit `WHERE title = ?`, so it could *TECHNICALLY* return the wrong length, but I'm not sure if this ever really ends up mattering; this is an edge case among edgecases, and almost always we just want PAGESIZE to return *something*.