### PR TITLE
Implement #filepath / filepath parser function

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -1424,7 +1424,7 @@ class Wtp:
                 # Call parser function
                 self.expand_stack.append(fn_name)
 
-                def expander(arg: str):
+                def expander(arg: str) -> str:
                     return expand_recurse(arg, parent, True)
 
                 if fn_name == "#invoke":

--- a/src/wikitextprocessor/parserfns.py
+++ b/src/wikitextprocessor/parserfns.py
@@ -1456,6 +1456,14 @@ def filepath_fn(
     return rf"//unimplemented/{args[0]}"
 
 
+def protectionlevel_fn(
+    ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
+) -> str:
+    """Implements the PROTECTIONLEVEL magic word."""
+    # Returns an empty string to indicate that the page is not protected."""
+    return ""
+
+
 # This list should include names of predefined parser functions and
 # predefined variables (some of which can take arguments using the same
 # syntax as parser functions and we treat them as parser functions).
@@ -1534,7 +1542,7 @@ PARSER_FUNCTIONS = {
     "NUMBEROFACTIVEUSERS": unimplemented_fn,
     "PAGEID": unimplemented_fn,
     "PAGESIZE": pagesize_fn,
-    "PROTECTIONLEVEL": unimplemented_fn,
+    "PROTECTIONLEVEL": protectionlevel_fn,
     "PROTECTIONEXPIRY": unimplemented_fn,
     "PENDINGCHANGELEVEL": unimplemented_fn,
     "PAGESINCATEGORY": unimplemented_fn,

--- a/src/wikitextprocessor/parserfns.py
+++ b/src/wikitextprocessor/parserfns.py
@@ -1440,6 +1440,22 @@ def pagesize_fn(
     return "0"
 
 
+def filepath_fn(
+    wtp: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
+) -> str:
+    # meaningless function in the context of parsing wikitext without
+    # access to the whole Mediawiki server core thingies.
+    # Return a dummy url in the form "//unimplemented/filepath.foo"
+
+    # The Scribunto PHP code parser function seems to also return
+    # an array [ $url, "nowiki" => true], but aren't all return values
+    # meant to be strings here? Testing it in the sandbox (using the
+    # 'nowiki' parameter) didn't give different results.
+    if not args:
+        return ""
+    return rf"//unimplemented/{args[0]}"
+
+
 # This list should include names of predefined parser functions and
 # predefined variables (some of which can take arguments using the same
 # syntax as parser functions and we treat them as parser functions).
@@ -1545,7 +1561,7 @@ PARSER_FUNCTIONS = {
     "fullurl": fullurl_fn,
     "fullurle": fullurl_fn,
     "canonicalurl": unimplemented_fn,
-    "filepath": unimplemented_fn,
+    "filepath": filepath_fn,
     "urlencode": urlencode_fn,
     "anchorencode": anchorencode_fn,
     "ns": ns_fn,

--- a/tests/test_parserfns.py
+++ b/tests/test_parserfns.py
@@ -48,6 +48,30 @@ class TestParserFunctions(TestCase):
             "14000",
         )
 
+    def test_filepath_fn1(self) -> None:
+        self.wtp.start_page("Test")
+        self.assertEqual(
+            self.wtp.expand("{{filepath:foo.jpg}}"), "//unimplemented/foo.jpg"
+        )
+
+    def test_filepath_fn2(self) -> None:
+        self.wtp.start_page("Test")
+        self.assertEqual(
+            self.wtp.expand("{{filepath:foo.jpg|nowiki}}"),
+            "//unimplemented/foo.jpg",
+        )
+
+    def test_filepath_fn3(self) -> None:
+        self.wtp.start_page("Test")
+        self.assertEqual(
+            self.wtp.expand("{{filepath:foo.jpg|300|nowiki}}"),
+            "//unimplemented/foo.jpg",
+        )
+
+    def test_filepath_fn4(self) -> None:
+        self.wtp.start_page("Test")
+        self.assertEqual(self.wtp.expand("{{filepath}}"), "")
+
     @patch(
         "wikitextprocessor.wikidata.query_wikidata",
         return_value={


### PR DESCRIPTION
Because we don't have access to the files (and shouldn't rely on them) and the search-function that returns a file url based on just the file name, this is implemented with a dummy URL that just starts with "//unimplemented/".

The double slash is a "protocol relative" url that seems to be the default (only?) form of url returned by #filepath, based on testing in the sandbox.

The original function has three return value variations:
- empty string when something goes wrong
- url
- PHP array [ $url, "nowiki" => true] -> Lua table -> Python dict {1: url, "nowiki": True}??

The last one is a mystery, but using the `nowiki` parameter doesn't seem to affect the return string at all. I'm not sure what it is supposed to be do, and why this happens when an array is returned. It's possible that the first value in the PHP array / Lua table is outputted, in which case you get the string, and because it was all packed in a table like this you get a 'nowiki' effect as a side-effect, and the `'nowiki' => true` is just documentation??