### PR TITLE
Getbadge

### DIFF
--- a/src/wikitextprocessor/lua/mw_wikibase.lua
+++ b/src/wikitextprocessor/lua/mw_wikibase.lua
@@ -23,7 +23,7 @@ function mw_wikibase.getEntityUrl(id)
    return nil
 end
 
-function mw_wikibase.getBadge(id, globalSiteId)
+function mw_wikibase.getBadges(id, globalSiteId)
    return {}
 end
 

--- a/src/wikitextprocessor/lua/mw_wikibase.lua
+++ b/src/wikitextprocessor/lua/mw_wikibase.lua
@@ -23,6 +23,10 @@ function mw_wikibase.getEntityUrl(id)
    return nil
 end
 
+function mw_wikibase.getBadge(id, globalSiteId)
+   return {}
+end
+
 function mw_wikibase.getLabel(id)
     return mw_wikibase_getlabel_python(id)
 end

--- a/tests/test_lua.py
+++ b/tests/test_lua.py
@@ -310,6 +310,28 @@ return export""",
         self.assertEqual(self.wtp.expand("{{#invoke:test|test}}"), "Q42Q42")
         mock_query.assert_called_once()  # use db cache
 
+    def test_wikibase_getBadge(self) -> None:
+        # getBadge is unimplemented, because we don't really need badge data
+        # for parsing. If this test fails, someone might have implemented
+        # getBadge properly, so you need to implement this as a proper test.
+        self.wtp.add_page(
+            "Module:test",
+            828,
+            """
+local export = {}
+function export.test(frame)
+  local a = mw.wikibase.getBadges("Douglas Adams", "enwiki")
+  if type(a) == 'table' and next(a) == nil then
+      return 'foo'
+  end
+  return  'bar'
+end
+return export""",
+            model="Scribunto",
+        )
+        self.wtp.start_page("")
+        self.assertEqual(self.wtp.expand("{{#invoke:test|test}}"), "foo")
+
     @patch("wikitextprocessor.wikidata.query_wikidata", return_value={})
     def test_wikibase_getEntityIdForTitle_no_result(self, mock_query):
         self.wtp.add_page(


### PR DESCRIPTION
Incomplete getBadge() implementation; return an empty table. We don't *really* need to know what badges a wikipedia page has for parsing, and this will fix issues.

getBadge was introduces in 2022~2023, so it is not strange it was unimplemented.

Afaict, the code doesn't call anything like Wikidata for the badge stuff, it's internal stuff (but with globalsiteid??), and I'm not even sure the dump data has badge data at all.