### PR TITLE
Implement dummy mw.ext.data.get function

### DIFF
--- a/src/wikitextprocessor/lua/mw.lua
+++ b/src/wikitextprocessor/lua/mw.lua
@@ -14,6 +14,7 @@ local mw_autoload = {
     ustring = "ustring:ustring",
     wikibase = "mw_wikibase",
     message = "mw_message",
+    ext = "mw_ext",
     getContentLanguage = function(table)
         return table.language.getContentLanguage
     end,

--- a/src/wikitextprocessor/lua/mw_ext.lua
+++ b/src/wikitextprocessor/lua/mw_ext.lua
@@ -1,0 +1,17 @@
+-- Simplified sub implementation of mw.ext for running WikiMedia Scribunto
+-- code under Python
+--
+-- Copyright (c) 2021 Tatu Ylonen.  See file LICENSE and https://ylonen.org
+
+-- https://doc.wikimedia.org/Wikibase/master/php/docs_topics_lua.html
+local mw_ext= { data = {}
+}
+
+function mw_ext.data.get(title, lang_code)
+    return { license = "CC0-1.0",
+             schema = { fields = {} },
+             data = {}
+           }
+end
+
+return mw_ext

--- a/src/wikitextprocessor/lua/mw_ext.lua
+++ b/src/wikitextprocessor/lua/mw_ext.lua
@@ -3,15 +3,18 @@
 --
 -- Copyright (c) 2021 Tatu Ylonen.  See file LICENSE and https://ylonen.org
 
--- https://doc.wikimedia.org/Wikibase/master/php/docs_topics_lua.html
-local mw_ext= { data = {}
-}
+-- https://www.mediawiki.org/wiki/Extension:Scribunto/Lua_reference_manual#mw.ext.data
+-- https://www.mediawiki.org/wiki/Extension:JsonConfig/Tabular
+-- https://www.mediawiki.org/wiki/Help:Tabular_Data
+local mw_ext = { data = {} }
 
+-- https://github.com/wikimedia/mediawiki-extensions-JsonConfig/blob/master/includes/JCLuaLibrary.php
 function mw_ext.data.get(title, lang_code)
-    return { license = "CC0-1.0",
-             schema = { fields = {} },
-             data = {}
-           }
+    return {
+        license = "CC0-1.0",
+        schema = { fields = {} },
+        data = {},
+    }
 end
 
 return mw_ext

--- a/tests/test_lua.py
+++ b/tests/test_lua.py
@@ -310,7 +310,7 @@ return export""",
         self.assertEqual(self.wtp.expand("{{#invoke:test|test}}"), "Q42Q42")
         mock_query.assert_called_once()  # use db cache
 
-    def test_wikibase_getBadge(self) -> None:
+    def test_wikibase_getBadges(self) -> None:
         # getBadge is unimplemented, because we don't really need badge data
         # for parsing. If this test fails, someone might have implemented
         # getBadge properly, so you need to implement this as a proper test.
@@ -356,6 +356,7 @@ return export""",
         # commons. Usually mw.ext.data.get loads data from static .tab files
         # and converts them to JSON -> table (with certain specific fields,
         # like .schema), but when retrieval fails it returns a { false } table.
+        # https://fr.wikipedia.org/wiki/Module:Tabular_data
         self.wtp.add_page(
             "Module:test",
             828,


### PR DESCRIPTION
mw.ext is a general namespace for Mediawiki
Lua extensions, and mw.ext.data is for
https://github.com/wikimedia/mediawiki-extensions-JsonConfig/

The extension is used to retrieve JSON data from
.tab files in (typically?) Commons space. The function returns a table with data containing:

`{ schema = { fields: { ... },
  data = { ... },
  license = "CC0-1.0"
}`

and some optional fields.

It also should be able to return a `{ false }` table as a negative result, but the problem we're trying to fix (French Wikipedia module using mw.ext.data.get) doesn't handle that gracefully, because it already 'knows' what data it should be getting.

The code we're targetting with this fix accesses both data.schema.fields and data.data with ipairs(), so we need to go that deep and put empty tables there to be iterated over.

Hopefully this is enough to prevent major Lua errors.