### PR TITLE
Some regex pattern object changes

### DIFF
--- a/src/wikitextprocessor/__init__.py
+++ b/src/wikitextprocessor/__init__.py
@@ -1,4 +1,5 @@
-from .core import MAGIC_FIRST, MAGIC_LAST, Page, Wtp
+from .common import MAGIC_FIRST, MAGIC_LAST
+from .core import Page, Wtp
 from .parser import NodeKind, WikiNode
 
 __all__ = (

--- a/src/wikitextprocessor/common.py
+++ b/src/wikitextprocessor/common.py
@@ -56,6 +56,7 @@ URL_STARTS = (
 MAGIC_FIRST: int = next(mnum)
 MAGIC_LAST: int = 0x0010FFF0
 MAX_MAGICS = MAGIC_LAST - MAGIC_FIRST + 1
+MAGIC_RE_PATTERN = re.compile(r"[{:c}-{:c}]".format(MAGIC_FIRST, MAGIC_LAST))
 
 # Mappings performed for text inside <nowiki>...</nowiki>
 _nowiki_map: dict[str, str] = {

--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -33,10 +33,10 @@ from typing import (
 
 from .common import (
     MAGIC_FIRST,
-    MAGIC_LAST,
     MAGIC_LBRACKET_CHAR,
     MAGIC_NOWIKI_CHAR,
     MAGIC_RBRACKET_CHAR,
+    MAGIC_RE_PATTERN,
     MAX_MAGICS,
     URL_STARTS,
     add_newline_to_expansion,
@@ -1333,9 +1333,7 @@ class Wtp:
                 assert isinstance(argmap, dict)
                 parts: list[str] = []
                 pos = 0
-                for m in re.finditer(
-                    r"[{:c}-{:c}]".format(MAGIC_FIRST, MAGIC_LAST), coded
-                ):
+                for m in MAGIC_RE_PATTERN.finditer(coded):
                     new_pos = m.start()
                     if new_pos > pos:
                         parts.append(coded[pos:new_pos])
@@ -1444,9 +1442,7 @@ class Wtp:
             # Main code of expand_recurse()
             parts: list[str] = []
             pos = 0
-            for m in re.finditer(
-                r"[{:c}-{:c}]".format(MAGIC_FIRST, MAGIC_LAST), coded
-            ):
+            for m in MAGIC_RE_PATTERN.finditer(coded):
                 new_pos = m.start()
                 if new_pos > pos:
                     parts.append(coded[pos:new_pos])
@@ -1765,9 +1761,7 @@ class Wtp:
         # We might get them from, e.g., unexpanded_template()
         while True:
             prev = text
-            text = re.sub(
-                r"[{:c}-{:c}]".format(MAGIC_FIRST, MAGIC_LAST), magic_repl, text
-            )
+            text = MAGIC_RE_PATTERN.sub(magic_repl, text)
             if prev == text:
                 break
 

--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -696,10 +696,9 @@ class Wtp:
 
         def repl_link(m: re.Match) -> CookieChar:
             """Replacement function for links [[...]]."""
-            m2 = re.search(
+            m2 = ALL_BRACKETS_RE.search(
                 # check to see if link contains something that should be
                 # handled first
-                ALL_BRACKETS_RE,
                 m.group(0)[2:-2],
             )
             if m2:
@@ -748,22 +747,14 @@ class Wtp:
                 prev2 = text
                 # Encode links.
                 while True:
-                    text = re.sub(
-                        LINKS_RE,
-                        repl_link,
-                        text,
-                    )
+                    text = LINKS_RE.sub(repl_link, text)
                     if text == prev2:
                         break
                     prev2 = text
                 # Encode external links: [something]
-                text = re.sub(EXTERNAL_LINKS_RE, repl_extlink, text)
+                text = EXTERNAL_LINKS_RE.sub(repl_extlink, text)
                 # Encode template arguments: {{{arg}}}, {{{..{|..|}..}}}
-                text = re.sub(
-                    TEMPLATE_ARGUMENTS_RE,
-                    repl_arg,
-                    text,
-                )
+                text = TEMPLATE_ARGUMENTS_RE.sub(repl_arg, text)
                 if text == prev2:
                     # When everything else has been done, see if we can find
                     # template arguments that have one missing closing bracket.
@@ -791,11 +782,7 @@ class Wtp:
                     #     continue
                     break
             # Replace template invocation
-            text = re.sub(
-                TEMPLATES_RE,
-                repl_templ,
-                text,
-            )
+            text = TEMPLATES_RE.sub(repl_templ, text)
             # We keep looping until there is no change during the iteration
             if text == prev:
                 # When everything else has been done, see if we can find

--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -823,8 +823,8 @@ class Wtp:
         # text = re.sub(r"[^|]\}", r"\1&rbrace;", text)
         # text = re.sub(r"[^|]\}", r"\1&rbrace;", text)
         # text = re.sub(r"\|", "&vert;", text)
-        text = re.sub(MAGIC_LBRACKET_CHAR, "[", text)
-        text = re.sub(MAGIC_RBRACKET_CHAR, "]", text)
+        text = text.replace(MAGIC_LBRACKET_CHAR, "[")
+        text = text.replace(MAGIC_RBRACKET_CHAR, "]")
         return text
 
     def _template_to_body(self, title: str, text: Optional[str]) -> str:
@@ -1773,14 +1773,14 @@ class Wtp:
 
         # Convert the special <nowiki /> character back to <nowiki />.
         # This is done at the end of normal expansion.
-        text = re.sub(MAGIC_NOWIKI_CHAR, "<nowiki />", text)
+        text = text.replace(MAGIC_NOWIKI_CHAR, "<nowiki />")
 
         # broken external url kludge: we don't want to have external
         # urls that are not correct, but we can't just return the
         # brackets as is inside the substitution loop, because that breaks
         # the loop, so we replace the characters and now return them.
-        text = re.sub(MAGIC_LBRACKET_CHAR, "[", text)
-        text = re.sub(MAGIC_RBRACKET_CHAR, "]", text)
+        text = text.replace(MAGIC_LBRACKET_CHAR, "[")
+        text = text.replace(MAGIC_RBRACKET_CHAR, "]")
         # print("    _finalize_expand:{!r}".format(text))
         return text
 

--- a/src/wikitextprocessor/parser.py
+++ b/src/wikitextprocessor/parser.py
@@ -2086,11 +2086,11 @@ def token_iter(ctx: "Wtp", text: str) -> Iterator[tuple[bool, str]]:
     on the same line."""
     assert isinstance(text, str)
     # Replace single quotes inside HTML tags with MAGIC_SQUOTE_CHAR
-    tag_parts = re.split(ctx.inside_html_tags_re, text)
+    tag_parts = ctx.inside_html_tags_re.split(text)
     if len(tag_parts) > 1:
         new_parts: list[str] = []
         for tp in tag_parts:
-            if re.match(ctx.inside_html_tags_re, tp):
+            if ctx.inside_html_tags_re.match(tp):
                 # we're inside an HTML tag
                 tp = tp.replace("'", MAGIC_SQUOTE_CHAR)
                 tp = tp.replace("\n", "")
@@ -2101,7 +2101,7 @@ def token_iter(ctx: "Wtp", text: str) -> Iterator[tuple[bool, str]]:
     parts_re = re.compile(r"('{2,})")
     for line in lines:
         # Detected headers before partitioning on "''"s
-        hm = re.match(header_re, line)
+        hm = header_re.match(line)
         if hm:
             token = hm.group(0)
             if token.startswith("="):
@@ -2191,7 +2191,7 @@ def token_iter(ctx: "Wtp", text: str) -> Iterator[tuple[bool, str]]:
             pos = 0
             # Revert to single quotes from MAGIC_SQUOTE_CHAR
             part = part.replace(MAGIC_SQUOTE_CHAR, "'")
-            for m in re.finditer(TOKEN_RE, part):
+            for m in TOKEN_RE.finditer(part):
                 start = m.start()
                 if pos != start:
                     yield False, part[pos:start]


### PR DESCRIPTION
Turns out https://github.com/tatuylonen/wikitextprocessor/commit/c25029df514c7e34820782476e6d297150081eaf makes the code slow(the `Wtp.preprocess_text()` function)... but `Wtp.process_text` is also called before `Wtp._encode()` in `Wtp.expand()`. This pr remedies a bit, after apply this pr the code is still twice slow as the code before c25029df514c7e34820782476e6d297150081eaf but faster than master.