### PR TITLE
Fix: mistaken implementation of mw.text.decode

### DIFF
--- a/src/wikitextprocessor/luaexec.py
+++ b/src/wikitextprocessor/luaexec.py
@@ -84,33 +84,19 @@ def lua_loader(ctx: "Wtp", modname: str) -> Optional[str]:
     return data
 
 
+html_entities_re = re.compile(r"&(lt|gt|amp|quot|nbsp|#[xX]?[0-9A-Fa-f]+);")
+
+
+def replace_specific_entities(m: re.Match) -> str:
+    return html.unescape(m.group(0))
+
+
 def mw_text_decode(text: str, decodeNamedEntities: bool) -> str:
     """Implements the mw.text.decode function for Lua code."""
     if decodeNamedEntities:
         return html.unescape(text)
 
-    # Otherwise decode only selected entities
-    parts: list[str] = []
-    pos = 0
-    for m in re.finditer(r"&(lt|gt|amp|quot|nbsp);", text):
-        if pos < m.start():
-            parts.append(text[pos : m.start()])
-        pos = m.end()
-        tag = m.group(1)
-        if tag == "lt":
-            parts.append("<")
-        elif tag == "gt":
-            parts.append(">")
-        elif tag == "amp":
-            parts.append("&")
-        elif tag == "quot":
-            parts.append('"')
-        elif tag == "nbsp":
-            parts.append("\xa0")
-        else:
-            assert False
-    parts.append(text[pos:])
-    return "".join(parts)
+    return html_entities_re.sub(replace_specific_entities, text)
 
 
 def mw_text_encode(text: str, charset: str) -> str:

--- a/tests/test_wikiprocess.py
+++ b/tests/test_wikiprocess.py
@@ -4099,9 +4099,7 @@ return export
         )
 
     def test_gsub5(self):
-        self.scribunto(
-            "42", """return string.gsub("x2A", "x%x+", "42");"""
-        )
+        self.scribunto("42", """return string.gsub("x2A", "x%x+", "42");""")
 
     def test_title_1_colon_e(self) -> None:
         self.scribunto("1:e", "return mw.title.new('1:e').text")


### PR DESCRIPTION
Our implementation of mw.text.decode was broken due to a misreading of
https://www.mediawiki.org/wiki/Extension:Scribunto/Lua_reference_manual#mw.text.decode

Here it is said that

> If boolean decodeNamedEntities is omitted or false,
> the only named entities recognized are `&lt;` (<),
> `&gt;` (>), `&amp;` (&), `&quot;` (") and `&nbsp;`
> (the non-breaking space, U+00A0).
> Otherwise, the list of HTML5 named entities to
> recognize is loaded from PHP's get_html_translation_table function.

Tatu read this as "if decodeNamedEntities is omitted or false, decode only these values", but it turns out that `decodeNamedEntities` is only required to decode *name entities* that aren't in this list; all number values are still decoded. I have no idea why this is like this, and I had the same misunderstanding when first looking at the documentation, but the Scribunto source code was clearer.

This was causing a ton of weird Lua errors in etymology templates, because there are bits of code that rely on the presence of a *asterisk, used in historical linguistics to denote a form of a word that is only reconstructed and not attested.

So when these entities were encoded into HTML entities (for some reason) and then the decode failed because our implementation was wonky, it broke the etymology template and it took me the hole day of hunt-and-peck print debugging to finally find where the fault was.