### PR TITLE
Fix HTML regex pattern and add a test for `mw.text.decode()`

### DIFF
--- a/src/wikitextprocessor/luaexec.py
+++ b/src/wikitextprocessor/luaexec.py
@@ -84,7 +84,7 @@ def lua_loader(ctx: "Wtp", modname: str) -> Optional[str]:
     return data
 
 
-html_entities_re = re.compile(r"&(lt|gt|amp|quot|nbsp|#[xX]?[0-9A-Fa-f]+);")
+HTML_DECODE_RE = re.compile(r"&(?:lt|gt|amp|quot|nbsp|#x?[a-zA-Z0-9]+);")
 
 
 def replace_specific_entities(m: re.Match) -> str:
@@ -92,11 +92,12 @@ def replace_specific_entities(m: re.Match) -> str:
 
 
 def mw_text_decode(text: str, decodeNamedEntities: bool) -> str:
-    """Implements the mw.text.decode function for Lua code."""
+    # https://www.mediawiki.org/wiki/Extension:Scribunto/Lua_reference_manual#mw.text.decode
+    # https://github.com/wikimedia/mediawiki-extensions-Scribunto/blob/c03d734c06812c9ee454c263f468d72894f6419c/includes/Engines/LuaCommon/lualib/mw.text.lua#L58-L89
     if decodeNamedEntities:
         return html.unescape(text)
 
-    return html_entities_re.sub(replace_specific_entities, text)
+    return HTML_DECODE_RE.sub(replace_specific_entities, text)
 
 
 def mw_text_encode(text: str, charset: str) -> str:

--- a/tests/test_lua.py
+++ b/tests/test_lua.py
@@ -390,3 +390,23 @@ return export""",
         )
         self.wtp.start_page("")
         self.assertEqual(self.wtp.expand("{{#invoke:test|test}}"), "foo")
+
+    def test_text_decode(self):
+        # GH pr #244
+        self.wtp.add_page(
+            "Module:test",
+            828,
+            """
+local export = {}
+function export.test(frame)
+  local a = mw.text.decode("&lt;-&vert;-&#124;-&#x7c;")
+  local b = mw.text.decode("&lt;-&vert;-&#124;-&#x7c;", true)
+  return a .. "--" .. b
+end
+return export""",
+            model="Scribunto",
+        )
+        self.wtp.start_page("")
+        self.assertEqual(
+            self.wtp.expand("{{#invoke:test|test}}"), "<-&vert;-|-|--<-|-|-|"
+        )


### PR DESCRIPTION
Upper case `X` before HTML entity number is not supported in Scribunto, so we could only use the lower case `x`.