### PR TITLE
Fix misuse of `Match.start()` causes template expanded as text bug

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -660,10 +660,9 @@ class Wtp:
             functions."""
             whole_match = m.group(0)
             nowiki = False
-            if (
-                MAGIC_NOWIKI_CHAR
-                in whole_match[: m.start(1)] + whole_match[m.end(1) :]
-            ):
+            if whole_match.startswith(
+                "{" + MAGIC_NOWIKI_CHAR
+            ) or whole_match.endswith(MAGIC_NOWIKI_CHAR + "}"):
                 nowiki = True  # <nowiki/> inside `{{` or `}}`
             args = vbar_split(m.group(1))
             if len(args) == 0 or args[0] == "":
@@ -674,11 +673,13 @@ class Wtp:
                     + "&vert;".join(args)
                     + "&rbrace;&rbrace;"
                 )
-            if ":" not in args[0] and MAGIC_NOWIKI_CHAR in args[0]:
+            first_arg = args[0].strip()
+            if not first_arg.startswith("#") and MAGIC_NOWIKI_CHAR in args[0]:
                 nowiki = True  # <nowiki/> before first pipe
             if (
-                ":" in args[0]
-                and MAGIC_NOWIKI_CHAR in args[0][: args[0].index(":")]
+                first_arg.startswith("#")
+                and ":" in first_arg
+                and MAGIC_NOWIKI_CHAR in first_arg[: first_arg.index(":")]
             ):
                 nowiki = True  # <nowiki/> before parser function name
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2843,7 +2843,7 @@ def foo(x):
                 "{{ t <nowiki/> }}",
                 "&lbrace;&lbrace; t <nowiki /> &rbrace;&rbrace;",
             ),
-            ("{{ t | <nowiki/> }}", "template body"),
+            ("random text {{ t | <nowiki/> }}", "random text template body"),
             (
                 "{{ #ifeq<nowiki/>: inYes | inYes | outYes | outNo }}",
                 "&lbrace;&lbrace; #ifeq<nowiki />: inYes &vert; inYes &vert; outYes &vert; outNo &rbrace;&rbrace;",  # noqa: E501


### PR DESCRIPTION
`m.start(1)` returns the location in the text passed to `re.sub()` not the location in the matched group text.

Fix https://github.com/tatuylonen/wiktextract/issues/533