### PR TITLE
Determine a HTML tag is self-closing if it ends with "/>"

### DIFF
--- a/src/wikitextprocessor/parser.py
+++ b/src/wikitextprocessor/parser.py
@@ -1808,15 +1808,14 @@ def tag_fn(ctx: "Wtp", token: str) -> None:
     # Try to parse it as a start tag
     m = re.match(
         r"""<([-a-zA-Z0-9]+)\s*((\b[-a-zA-Z0-9:]+(\s*=\s*("[^"]*"|"""
-        r"""'[^']*'|[^ \t\n"'`=<>]*))?\s*)*)(/?)>""",
+        r"""'[^']*'|[^ \t\n"'`=<>]*))?\s*)*)/?>""",
         token,
     )
-    if m:
+    if m is not None:
         # This is a start tag
-        name = m.group(1)
+        name = m.group(1).lower()
         attrs = m.group(2)
-        also_end = m.group(6) == "/"
-        name = name.lower()
+        also_end = m.group(0).endswith("/>")
 
         # Some templates have markers like <1> in their arguments.  Only parse
         # valid HTML tags in template arguments (tags like <math> can and

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2854,6 +2854,21 @@ def foo(x):
             with self.subTest(wkitext=wikitext, result=result):
                 self.assertEqual(self.ctx.expand(wikitext), result)
 
+    def test_html_end_tag_slash_after_attr(self):
+        # the "/" in "/>" should not be parsed as attribute value
+        # https://en.wiktionary.org/wiki/abstract
+        # GH issue tatuylonen/wiktextract#535
+        self.ctx.start_page("abstract")
+        root = self.ctx.parse("""{{en-adj|more|er}}<ref name=dict/>
+# {{lb|en|obsolete}} Derived; extracted.""")
+        self.assertEqual(len(root.children), 4)
+        self.assertIsInstance(root.children[0], TemplateNode)
+        self.assertEqual(root.children[0].template_name, "en-adj")
+        self.assertIsInstance(root.children[1], HTMLNode)
+        self.assertEqual(root.children[1].tag, "ref")
+        self.assertEqual(root.children[2], "\n")
+        self.assertEqual(root.children[3].kind, NodeKind.LIST)
+
 
 # XXX implement <nowiki/> marking for links, templates
 #  - https://en.wikipedia.org/wiki/Help:Wikitext#Nowiki


### PR DESCRIPTION
Fixes tatuylonen/wiktextract#535

It works for now, but we'll have more errors with this regex in the future, only using a real HTML parser could fix them.