### PR TITLE
Add `//` to allowed URL prefixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Run "make test" to run tests
 # Run "make clean" to remove automatically generated files
-ruff:
+rcheck:
 	python -m ruff check --diff src/wikitextprocessor
 	python -m ruff check --diff tests
 test:

--- a/src/wikitextprocessor/common.py
+++ b/src/wikitextprocessor/common.py
@@ -49,6 +49,11 @@ URL_STARTS = (
     "git://",
     "mms://",
     "mailto:",
+    "//",  # Internal only! // is a wikitext short-hand for "use the url_start
+    # that this page has, so //fr.wikipedia.org > https://fr.wiki...
+    # when appropriate. For internal use, let's just allow it so that
+    # URL parsing doesn't break when something generates an un-
+    # processed URL like this.
 )
 
 # Magic characters used to store templates and other expandable


### PR DESCRIPTION
`//` is a wiki-internal URL prefix that means 'take the url prefix (https:// or http:// usually) and replace this `//` with it'. But we don't handle URLs in-between like this, it doesn't make any sense for us to do so without a website that a user is accessing, so for now let's just allow `//` links as valid links.

Parallel change on the Wiktextract side of things in clean_values, where we start to use URL_STARTS to check for valid URLs, too.