### PR TITLE
Implement mw.language:formatDate()

### DIFF
--- a/src/wikitextprocessor/lua/mw_language.lua
+++ b/src/wikitextprocessor/lua/mw_language.lua
@@ -155,12 +155,11 @@ end
 
 function Language:formatDate(format, timestamp, localtime)
     -- XXX currently ignores localtime
-    if format == "U" then
-        timestamp = os.time()
-    elseif not timestamp then
+    if not timestamp and not format then
         timestamp = os.date("%Y-%m-%d %X")
+    else
+        timestamp = mw_language_format_date_python(format, timestamp, localtime)
     end
-    -- XXX actually format the time.  See
     -- https://www.mediawiki.org/wiki/Help:Extension:ParserFunctions#.23time
     -- form supported timestamp formats and format specification.
     return timestamp


### PR DESCRIPTION
Issue #226 case 'Durée'

mw.language:formatDate() was only partially implemented.

However, the same kind of code needed there has already been (mostly?) implemented in the `{{#time:...}}` parser function in parserfns, so we can reuse code from there by refactoring the meaningful bits out and making a new mw_language_format_date_python function to be called from Lua code that will do most of the things needed here.

I spent too much time trying to roll my own implementation... before realizing there already was one in parserfns!!