### PR TITLE
Install lupa package's wheel file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ requires-python = ">=3.9"
 dependencies = [
     "dateparser",
     "importlib_resources; python_version < '3.10'",
-    "lupa @ git+https://github.com/scoder/lupa.git",
+    "lupa",
     "lxml",
     "mediawiki_langcodes",
     "psutil",


### PR DESCRIPTION
lupa 2.1 is released, we finally don't have to build lupa from source.