### PR TITLE
Fix the rest errors when expanding French Wiktionary's "liste des dirigeants successifs" template in page "Ford"

### DIFF
--- a/src/wikitextprocessor/lua/mw_title.lua
+++ b/src/wikitextprocessor/lua/mw_title.lua
@@ -105,8 +105,10 @@ end
 
 function mw_title_meta:fullUrl(query, proto)
     local uri = mw.uri.fullUrl(self.fullText, query)
-    if proto ~= nil and proto ~= "" then uri = proto .. ":" .. uri end
-    return uri
+    if proto ~= nil and proto ~= "" then uri.proto = proto end
+    uri.fragment = self.fragment
+    uri:update()
+    return tostring(uri)
 end
 
 function mw_title_meta:localUrl(query)

--- a/src/wikitextprocessor/lua/mw_uri.lua
+++ b/src/wikitextprocessor/lua/mw_uri.lua
@@ -249,9 +249,11 @@ function mw_uri.fullUrl(page, query)
    local uri = Uri:new{}
    uri:extend({title=page})
    uri:extend(query)
-   local ret = "//" .. uri.hostPort .. uri.relativePath
-   if fragment ~= "" then ret = ret .. "#" .. fragment end
-   return ret
+   if fragment ~= "" then
+       uri.fragment = fragment
+       uri:update()
+   end
+   return uri
 end
 
 function mw_uri.canonicalUrl(page, query)

--- a/src/wikitextprocessor/lua/mw_wikibase.lua
+++ b/src/wikitextprocessor/lua/mw_wikibase.lua
@@ -93,7 +93,11 @@ function mw_wikibase.getBestStatements(entityId, propertyId)
 end
 
 function mw_wikibase.getAllStatements(entityId, propertyId)
-   return {}
+    local entity = mw.wikibase.getEntity(entityId)
+    if entity ~= nil then
+        return entity.claims[propertyId] or {}
+    end
+    return {}
 end
 
 function mw_wikibase.getReferencedEntityId(fromEntityId, propertyId, toIds)

--- a/src/wikitextprocessor/luaexec.py
+++ b/src/wikitextprocessor/luaexec.py
@@ -45,7 +45,7 @@ from .parserfns import (
 if TYPE_CHECKING:
     from lupa.lua51 import _LuaTable
 
-    from .core import NamespaceDataEntry, ParentData, Wtp
+    from .core import ParentData, Wtp
 
 # List of search paths for Lua libraries
 BUILTIN_LUA_SEARCH_PATHS: list[tuple[str, list[str]]] = [
@@ -328,18 +328,10 @@ def initialize_lua(ctx: "Wtp") -> None:
         attribute_filter=filter_attribute_access,
     )
     ctx.lua = lua
-    lua_namespace_data = copy.deepcopy(ctx.NAMESPACE_DATA)
-    ns_name: str
-    ns_data: NamespaceDataEntry
-    for ns_name, ns_data in lua_namespace_data.items():
-        for k, v in ns_data.items():
-            if isinstance(v, list):
-                lua_namespace_data[ns_name][k] = lua.table_from(v)  # type: ignore[literal-required]
-        lua_namespace_data[ns_name] = lua.table_from(  # type: ignore[assignment]
-            lua_namespace_data[ns_name]
-        )
     set_global_lua_variable(
-        lua, "NAMESPACE_DATA", lua.table_from(lua_namespace_data)
+        lua,
+        "NAMESPACE_DATA",
+        lua.table_from(copy.deepcopy(ctx.NAMESPACE_DATA), recursive=True),  # type: ignore
     )
     set_lua_env_funcs(lua, ctx)
 

--- a/src/wikitextprocessor/wikidata.py
+++ b/src/wikitextprocessor/wikidata.py
@@ -389,4 +389,4 @@ def mw_wikibase_getEntity(wtp: "Wtp", item_id: Optional[str]) -> Any:
     entity_data = get_entity_data(wtp, item_id)
     if entity_data is None or wtp.lua is None:
         return None
-    return wtp.lua.table_from(entity_data)
+    return wtp.lua.table_from(entity_data, recursive=True)  # type:ignore

--- a/src/wikitextprocessor/wikidata.py
+++ b/src/wikitextprocessor/wikidata.py
@@ -213,14 +213,26 @@ def get_item_cache(wtp: "Wtp", item_id: str) -> Optional[WikiDataItem]:
 
 
 def insert_item(wtp: "Wtp", item: WikiDataItem) -> None:
-    wtp.db_conn.execute(
-        """
-        INSERT OR IGNORE INTO wikidata_items
-        (id, label, description, entity_data)
-        VALUES(?, ?, ?, ?)
-        """,
-        (item.item_id, item.label, item.description, item.entity_data),
-    )
+    if len(item.entity_data) > 0:
+        wtp.db_conn.execute(
+            """
+            INSERT INTO wikidata_items
+            (id, label, description, entity_data)
+            VALUES(?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+            entity_data=excluded.entity_data
+            """,
+            (item.item_id, item.label, item.description, item.entity_data),
+        )
+    else:
+        wtp.db_conn.execute(
+            """
+            INSERT OR IGNORE INTO wikidata_items
+            (id, label, description, entity_data)
+            VALUES(?, ?, ?, ?)
+            """,
+            (item.item_id, item.label, item.description, item.entity_data),
+        )
 
 
 def query_item(wtp: "Wtp", item_id: str, lang_code: str) -> WikiDataItem:

--- a/tests/test_lua.py
+++ b/tests/test_lua.py
@@ -441,3 +441,34 @@ return export""",
         self.wtp.start_page("")
         self.assertEqual(self.wtp.expand("{{#invoke:test|test}}"), "Q42Q42")
         mock_request.assert_called_once()
+
+    @patch(
+        "requests.get",
+        return_value=MockRequests(
+            True,
+            {
+                "entities": {
+                    "Q42": {
+                        "id": "Q42",
+                        "claims": {
+                            "P31": [{"type": "statement", "rank": "normal"}]
+                        },
+                    }
+                }
+            },
+        ),
+    )
+    def test_wikidata_get_all_statements(self, mock_request):
+        self.wtp.add_page(
+            "Module:test",
+            828,
+            """
+local export = {}
+function export.test(frame)
+  return mw.wikibase.getAllStatements("Q42", "P31")[1].type
+end
+return export""",
+            model="Scribunto",
+        )
+        self.wtp.start_page("")
+        self.assertEqual(self.wtp.expand("{{#invoke:test|test}}"), "statement")

--- a/tests/test_wikiprocess.py
+++ b/tests/test_wikiprocess.py
@@ -3361,9 +3361,8 @@ return export
 
     def test_mw_uri16(self):
         self.scribunto(
-            "//wiki.local/w/index.php?action=edit&title=Example",
-            r"""
-        return mw.uri.fullUrl("Example", {action="edit"})""",
+            "https://wiki.local/w/index.php?action=edit&title=Example",
+            'return tostring(mw.uri.fullUrl("Example", {action="edit"}))',
         )
 
     def test_mw_title1(self):
@@ -3837,10 +3836,11 @@ return export
 
     def test_mw_title54(self):
         self.scribunto(
-            "http://wiki.local/w/index.php?" "a=1&title=Test%2Ffoo%2Fb+ar#Frag",
-            r"""
-        local t = mw.title.makeTitle("Main", "Test/foo/b ar", "Frag")
-        return t:fullUrl({a=1}, "http")""",
+            "https://wiki.local/w/index.php?a=1&title=Test%2Ffoo%2Fb+ar#Frag",
+            """
+            local t = mw.title.makeTitle("Main", "Test/foo/b ar", "Frag")
+            return t:fullUrl({a=1}, "http")
+            """,
         )
 
     def test_mw_title55(self):


### PR DESCRIPTION
#260 fixes the error at here: https://fr.wikipedia.org/wiki/Module:Titulaires#L-904, but the template expands to empty string because `mw.wikibase.getAllStatements()` returns an empty table. With this pr's changes the "liste des dirigeants successifs" template in page (Ford)[https://fr.wikipedia.org/wiki/Ford] will be expanded to a table successfully.

I didn't update the Lupa type file, IMO it's an unnecessary maintenance burden and should be removed... 