### PR TITLE
Fix 'AttributeError' object has no attribute 'gsub' error in de edition

### DIFF
--- a/src/wikitextprocessor/luaexec.py
+++ b/src/wikitextprocessor/luaexec.py
@@ -537,7 +537,7 @@ def call_lua_sandbox(
                 for arg in args[1:]:
                     if isinstance(arg, (int, float, str)):
                         new_args.append(str(arg))
-                    else:
+                    elif isinstance(arg, dict) or lua_type(arg) == "table":
                         for k, v in sorted(
                             arg.items(), key=lambda x: str(x[0])
                         ):

--- a/src/wikitextprocessor/parserfns.py
+++ b/src/wikitextprocessor/parserfns.py
@@ -1266,6 +1266,21 @@ def time_fn(
     return ret
 
 
+def timel_fn(
+    wtp: "Wtp",
+    fn_name: str,
+    args: Union[list[str], tuple[str, ...]],
+    expander: Callable[[str], str],
+) -> str:
+    # `local` parameter set to true
+    if isinstance(args, tuple):
+        args = list(args)
+    while len(args) < 3:
+        args.append("")
+    args.append("1")
+    return time_fn(wtp, fn_name, args, expander)
+
+
 def len_fn(
     ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
@@ -1698,7 +1713,7 @@ PARSER_FUNCTIONS = {
     "padright": padright_fn,
     "plural": plural_fn,
     "#time": time_fn,
-    "#timel": unimplemented_fn,
+    "#timel": timel_fn,
     "gender": unimplemented_fn,
     "#tag": tag_fn,
     "localurl": localurl_fn,

--- a/tests/test_lua.py
+++ b/tests/test_lua.py
@@ -472,3 +472,22 @@ return export""",
         )
         self.wtp.start_page("")
         self.assertEqual(self.wtp.expand("{{#invoke:test|test}}"), "statement")
+
+    def test_pass_nil_to_callParserFunction(self):
+        # https://de.wiktionary.org/wiki/anachoreta
+        # https://de.wiktionary.org/wiki/Modul:DateTime#L-1218
+        self.wtp.add_page(
+            "Module:test",
+            828,
+            """
+local export = {}
+function export.test(frame)
+  return frame:callParserFunction("#tag", "a", "text", nil)
+end
+return export""",
+            model="Scribunto",
+        )
+        self.wtp.start_page("")
+        self.assertEqual(
+            self.wtp.expand("{{#invoke:test|test}}"), "<a>text</a>"
+        )

--- a/tests/test_parserfns.py
+++ b/tests/test_parserfns.py
@@ -155,3 +155,12 @@ class TestParserFunctions(TestCase):
         self.wtp.start_page("")
         expanded = self.wtp.expand("{{#statements:date of birth|from=Q42}}")
         self.assertEqual(expanded, "11 March 1952")
+
+    def test_timel(self):
+        from datetime import datetime, timezone
+
+        self.wtp.start_page("")
+        expanded = self.wtp.expand("{{#timel:c}}")
+        time = datetime.fromisoformat(expanded)
+        delta = datetime.now(timezone.utc) - time
+        self.assertLess(abs(delta.total_seconds()), 1)


### PR DESCRIPTION
Error message: https://kaikki.org/dewiktionary/errors/details--AttributeError--object-has-no-attribu--jaFhCzt.html

It's really difficult to fix bugs like this without stack trace of the "pcall" Lua function...