### PR TITLE
Change to link detection regex

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -161,16 +161,34 @@ LINKS = (
     # `[[something<abcd>]]`
     # XXX this regex seems to be too complex,
     # could you replace it with just [^][{}]*?
-    r"\["
+    r"(?<!\[)"
+    + r"\["
     + MAGIC_NOWIKI_CHAR
     + r"?\[("
-    # I spent a lot of willpower on this monstrosity.
-    + r"((?!\]\])[^[\n])*(?!\[[\n]+\])((?!\[\[)[^]\n])+"
-    #   ( no ]] ) ( no [ ) ( no [...] )( no [[) (no ])
+    + r"(((?!\]\])[^[\|\n])*((?!\[\[)[^]\n])+)"
+    + r"(\|(((?!\]\])[^[])*((?!\[\[)[^]])+))?"  # after pipe no newlines, optnl.
     + r")\]"
     + MAGIC_NOWIKI_CHAR
     + r"?\]"
 )
+# (?<!\[)    # negative lookbehind,
+#            # [[[ breaks the link completely,
+#            # the whole thing is not parsed as a link or url
+# \[MAGIC_NOWIKI?\[      # start brackets
+# (, optnl.
+#   (
+#     (?!\]\])    # negative lookahead, no ]] allowed
+#     [^[\n]
+#   )*    # no [ or newlines allowed
+#   (
+#      (?!\[\[)   # no [[ allowed
+#      [^]\n]    # no ] or newlines
+#   )+
+# )
+# (\|  # after a |, newlines are allowed, the below is the same as above
+#   (((?!\]\])[^[])*((?!\[\[)[^]])+)
+# )?
+# \]MAGIC_NOWIKI?\]
 
 LINKS_RE = re.compile(LINKS)
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1094,6 +1094,15 @@ dasfasddasfdas
     #     self.assertEqual(link.kind, NodeKind.LINK)
     #     self.assertEqual(link.largs, [["foo"], [" [bar]"]])
 
+    def test_link12(self):
+        # Apparently, the text portion of a link is allowed newlines, after
+        # the | pipe.
+        tree = self.parse("test", "[[foo|\n[bar]]")
+        # print_tree(tree)
+        link = tree.children[0]
+        self.assertEqual(link.kind, NodeKind.LINK)
+        self.assertEqual(link.largs, [["foo"], ["\n[bar"]])
+
     def test_link_trailing(self):
         tree = self.parse("test", "[[Help]]ing heal")
         self.assertEqual(len(tree.children), 2)


### PR DESCRIPTION
Should fix #266

The previous version did not allow for links with newlines in the text portion of the link:

```
[[this link|

should be

accepted]]
```

Newlines are not allowed in the link data portion ('this link').

Because of the negative lookahead stuff to detect `[[`, `]]` and `[`, `]` pairs inside the links, it's a real monster of a regex that's hard to read.

I also found a minor bug that meant a part of the regex was basically disabled, so I just removed it (no ^ to negate \n in [\n]).

Also added a negative lookbehind: a link starting with `[[[` is parsed as text.