### PR TITLE
Match quoted `begin` `end` attribute of the `section` tag for `#lst`

### DIFF
--- a/src/wikitextprocessor/parserfns.py
+++ b/src/wikitextprocessor/parserfns.py
@@ -150,7 +150,11 @@ def categorytree_fn(
 def lst_fn(
     ctx: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
 ) -> str:
-    """Implements the #lst (alias #section etc) parser function."""
+    """
+    Implements the #lst (alias #section etc) parser function.
+
+    https://www.mediawiki.org/wiki/Extension:Labeled_Section_Transclusion#Transclude_any_marked_part
+    """
     pagetitle = expander(args[0]).strip() if args else ""
     chapter = expander(args[1]).strip() if len(args) >= 2 else ""
     text = ctx.get_page_body(pagetitle, 0)
@@ -164,8 +168,7 @@ def lst_fn(
 
     parts: list[str] = []
     for m in re.finditer(
-        r"(?si)<\s*section\s+begin={}\s*/\s*>(.*?)"
-        r"<\s*section\s+end={}\s*/\s*>".format(
+        r'(?si)<section\s+begin="?{}"?\s*/>(.*?)<section\s+end="?{}"?\s*/>'.format(
             re.escape(chapter), re.escape(chapter)
         ),
         text,

--- a/tests/test_wikiprocess.py
+++ b/tests/test_wikiprocess.py
@@ -370,10 +370,10 @@ return export
             title="Test title",
             namespace_id=0,
             body="""
-<section begin=foo />
+<section begin="foo" />
 === Test section ===
 A
-<section end=foo />
+<section end="foo" />
 
 === Other section ===
 B
@@ -382,13 +382,13 @@ B
 MORE
 <section end=foo />
 
-<section begin=bar />
+<section begin="bar" />
 NOT
-<section end=bar />
+<section end="bar" />
 """,
         ),
     )
-    def test_lst1(self, mock_get_page):
+    def test_lst_fn(self, mock_get_page):
         self.ctx.start_page("Tt")
         ret = self.ctx.expand("{{#lst:testpage|foo}}")
         self.assertEqual(


### PR DESCRIPTION
Quotation mark should be used, both `#lst`'s document and real use case(ru edition page "поверхностный") has the marks.

But I don't know when the `#lst` function in that ru page is expanded. 