### PR TITLE
Remove unnecessary warning and logging setting code

### DIFF
--- a/src/wikitextprocessor/parserfns.py
+++ b/src/wikitextprocessor/parserfns.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2020-2022 Tatu Ylonen.  See file LICENSE and https://ylonen.org
 
 import html
-import logging
 import math
 import re
 import urllib.parse
@@ -19,19 +18,6 @@ from .interwiki import get_interwiki_map
 if TYPE_CHECKING:
     # Reached only by mypy or other type-checker
     from .core import Wtp
-
-# Suppress some warnings that are out of our control
-import warnings
-
-warnings.filterwarnings(
-    "ignore", r".*The localize method is no longer necessary.*"
-)
-
-# attempt at suppressing a bunch of unnecessary logging messages
-# polluting wiktextract.log. `logging` is not used in wikitextprocessor
-# otherwise
-logging.getLogger("datetime").setLevel(logging.WARNING)
-logging.getLogger("dateparser").setLevel(logging.WARNING)
 
 # https://www.mediawiki.org/wiki/Help:Extension:ParserFunctions
 # https://www.mediawiki.org/wiki/Help:Magic_words


### PR DESCRIPTION
- DEBUG logging level is only set to our own `Logger` obejct in wiktextract code and won't affect other packages: tatuylonen/wiktextract#591
- I guess the warning filter was added for the "dateparser" package, this was fixed two years ago(dateparser GH issue 1013)