### PR TITLE
Run `mw.loadData()` in cloned environment

### DIFF
--- a/src/wikitextprocessor/lua/_sandbox_phase1.lua
+++ b/src/wikitextprocessor/lua/_sandbox_phase1.lua
@@ -134,7 +134,7 @@ local function new_loadData(modname)
         return loaddata_cache[modname]
     end
     -- Load the module and create initialization function
-    local fn, msg = new_loader(modname)
+    local fn, msg = new_loader(modname, mw_clone(env))
     assert(fn, msg)
     local ret = fn()
 


### PR DESCRIPTION
As the Scribunto code and the GH issues(#90, #258) shows, `mw.loadData()` runs in a cloned environment so the caller env doesn't affect the code runs inside `loadData`.

I finally sort of understand this clone env problem...