### PR TITLE
Create `Logger` object and set `Logging.DEBUG` level

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -42,6 +42,7 @@ from .common import (
     add_newline_to_expansion,
     nowiki_quote,
 )
+from .logging_utils import logger
 from .luaexec import call_lua_sandbox
 from .node_expand import NodeHandlerFnCallable, to_html, to_text, to_wikitext
 from .parser import (
@@ -294,6 +295,7 @@ class Wtp:
         extension_tags: Optional[dict[str, HTMLTagData]] = None,
         invoke_aliases: Optional[set[str]] = None,
         file_aliases: Optional[set[str]] = None,
+        quiet: bool = False,
     ):
         if isinstance(db_path, str):
             self.db_path: Optional[Path] = Path(db_path)
@@ -353,6 +355,8 @@ class Wtp:
         self.invoke_aliases = {"#invoke"}
         if invoke_aliases is not None:
             self.invoke_aliases |= invoke_aliases
+        if not quiet:
+            logger.setLevel(logging.DEBUG)
 
     def create_db(self) -> None:
         from .wikidata import init_wikidata_cache
@@ -1103,7 +1107,7 @@ class Wtp:
         tags.  Such templates generally need to be expanded before
         parsing the page."""
 
-        logging.info(
+        logger.info(
             "Analyzing which templates should be expanded before parsing"
         )
         template_ns_data = self.NAMESPACE_DATA.get("Template")

--- a/src/wikitextprocessor/dumpparser.py
+++ b/src/wikitextprocessor/dumpparser.py
@@ -4,7 +4,6 @@
 
 import hashlib
 import json
-import logging
 import os
 import shutil
 import subprocess
@@ -17,6 +16,7 @@ if TYPE_CHECKING:
     from .core import Wtp
 
 from .interwiki import init_interwiki_map
+from .logging_utils import logger
 
 
 def decompress_dump_file(dump_path: str) -> subprocess.Popen:
@@ -85,7 +85,7 @@ def parse_dump_xml(wtp: "Wtp", dump_path: str, namespace_ids: set[int]) -> None:
             page_element.clear(keep_tail=True)
             page_nums += 1
             if page_nums % 10000 == 0:
-                logging.info(f"  ... {page_nums} raw pages collected")
+                logger.info(f"  ... {page_nums} raw pages collected")
 
 
 def process_dump(
@@ -103,11 +103,11 @@ def process_dump(
     file with some preprocessing.  The Wtp.reprocess() must then be
     called to actually process the data."""
 
-    logging.info(
+    logger.info(
         f"skip_extract_dump: {skip_extract_dump}, save_pages_path: "
         f"{str(save_pages_path)}"
     )
-    logging.info(f"dump file path: {path}")
+    logger.info(f"dump file path: {path}")
 
     # Run Phase 1 in a single thread; this mostly just extracts pages into
     # a SQLite database file.
@@ -175,7 +175,7 @@ def overwrite_pages(
     """
     for folder_path in folder_paths:
         if not folder_path.exists():
-            logging.warning(f"Override path: {folder_path} doesn't exist.")
+            logger.warning(f"Override path: {folder_path} doesn't exist.")
             continue
 
         if folder_path.is_file() and folder_path.suffix == ".json":
@@ -204,7 +204,7 @@ def overwrite_pages(
             with file_path.open(encoding="utf-8") as f:
                 first_line = f.readline()
                 if not first_line.startswith("TITLE: "):
-                    logging.error(
+                    logger.error(
                         "First line of file supplied with --override must be "
                         '"TITLE: <page title>" (The page title for this would '
                         "normally start with Module:"

--- a/src/wikitextprocessor/logging_utils.py
+++ b/src/wikitextprocessor/logging_utils.py
@@ -1,0 +1,4 @@
+import logging
+
+logging.basicConfig(format="%(asctime)s %(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)


### PR DESCRIPTION
Our previous code use the root logger configed in wiktextract code, but now wiktextract doesn't use root logger thus all info level logs are not printed.