### PR TITLE
Remove the limit of unnamed template argument number

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -1602,13 +1602,6 @@ class Wtp:
                             k, arg = m2.groups()
                             if k.isdigit():
                                 k = int(k)
-                                if k < 1 or k > 1000:
-                                    self.debug(
-                                        "invalid argument number {} "
-                                        "for template {!r}".format(k, name),
-                                        sortid="core/1211",
-                                    )
-                                    k = 1000
                             else:
                                 self.expand_stack.append("ARGNAME")
                                 k = expand_recurse(k, parent, True)


### PR DESCRIPTION
0 and above 1000 are allowed in MediaWiki, for example, fr edition's "cardinaux/vi" template:
https://fr.wiktionary.org/wiki/Modèle:cardinaux/vi