### PR TITLE
Don't add too many template args debug message for empty args

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -1387,7 +1387,9 @@ class Wtp:
                         continue
                     if kind == "A":
                         # Template argument reference
-                        if len(args) > 2:
+                        if len(args) > 2 and any(
+                            len(arg.strip()) > 0 for arg in args[2:]
+                        ):
                             self.debug(
                                 "too many args ({}) in argument "
                                 "reference: {!r}".format(len(args), args),

--- a/tests/test_node_expand.py
+++ b/tests/test_node_expand.py
@@ -294,3 +294,11 @@ class NodeExpTests(unittest.TestCase):
         self.ctx.start_page("newline")
         self.assertEqual(self.ctx.expand("{{#if: true | text}}"), "text")
         self.assertEqual(self.ctx.expand("{{#if: true | * list}}"), "\n* list")
+
+    def test_no_debug_message_for_extra_empty_template_argument(self):
+        # https://zh.wiktionary.org/wiki/Template:Context
+        # https://de.wiktionary.org/wiki/Vorlage:Literatur
+        self.ctx.start_page("")
+        self.ctx.add_page("Template:test", 10, "{{{1||}}}")
+        self.assertEqual(self.ctx.expand("{{test|t}}"), "t")
+        self.assertEqual(len(self.ctx.debugs), 0)


### PR DESCRIPTION
It's not uncommon in non-en editions to have `{{{x||}}}` in templates.