### PR TITLE
Change external links `[...]` regex

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -194,7 +194,8 @@ LINKS = (
 LINKS_RE = re.compile(LINKS)
 
 # Encode external links: [something]
-EXTERNAL_LINKS = r"\[([^][{}<>|\n]+)\]"
+# [test]]+ breaks in sandbox, so prevent with negative lookahead
+EXTERNAL_LINKS = r"\[([^][{}<>|\n]+)\](?!\])"
 
 EXTERNAL_LINKS_RE = re.compile(EXTERNAL_LINKS)
 


### PR DESCRIPTION
`[test]]` is not a valid link, so prevent that with negative lookahead. This caused problems in cases like:

  {{quote-book|en|author=[[w:Theodore Beza|Theodore de Beza]]
  |tlr=[[w:Robert Fills|R[obert] F[ills&#93;]]......

with the open `[` bracket messing with the last `]]` token, causing the later LINKS_RE pattern call to basically take ages.