### PR TITLE
Remove upper case substitution modifiers

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -1522,7 +1522,9 @@ class Wtp:
                     tname = (
                         tname.strip()
                         .removeprefix("subst:")
+                        .removeprefix("SUBST:")
                         .removeprefix("safesubst:")
+                        .removeprefix("SAFESUBST:")
                     )
 
                     # Check if it is a parser function call


### PR DESCRIPTION
an upper case "SAFESUBST:" is used in https://en.wiktionary.org/wiki/Template:ordinal

Issue https://github.com/tatuylonen/wiktextract/issues/663