### PR TITLE
Only parse `----` as horizontal rule if it's at the start of line

### DIFF
--- a/src/wikitextprocessor/parser.py
+++ b/src/wikitextprocessor/parser.py
@@ -2256,7 +2256,7 @@ def process_text(ctx: "Wtp", text: str) -> None:
                 subtitle_end_fn(ctx, token)
             elif token.startswith("<"):  # HTML tag like construct
                 tag_fn(ctx, token)
-            elif token.startswith("----"):
+            elif token.startswith("----") and ctx.beginning_of_line:
                 hline_fn(ctx, token)
             elif re.match(list_prefix_re, token):
                 list_fn(ctx, token)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2920,6 +2920,18 @@ def foo(x):
         self.assertEqual(span_text, "example text")
         self.assertEqual(dd_text, "translation text")
 
+    def test_horizontal_rule_in_template_arg(self):
+        # GitHub issue tatuylonen/wiktextract#536
+        self.ctx.start_page("shithole")
+        root = self.ctx.parse("{{alt|en|—hole|----hole}}")
+        template_node = root.children[0]
+        self.assertIsInstance(template_node, TemplateNode)
+        self.assertEqual(len(root.children), 1)
+        self.assertEqual(
+            template_node.template_parameters,
+            {1: "en", 2: "—hole", 3: "----hole"},
+        )
+
 
 # XXX implement <nowiki/> marking for links, templates
 #  - https://en.wikipedia.org/wiki/Help:Wikitext#Nowiki


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Help:Wikitext#Horizontal_rule

GitHub issue tatuylonen/wiktextract#536