### PR TITLE
Set empty string as Lua title object `fragment` field default value

### DIFF
--- a/src/wikitextprocessor/lua/mw_title.lua
+++ b/src/wikitextprocessor/lua/mw_title.lua
@@ -248,7 +248,7 @@ function mw_title.makeTitle(namespace, title, fragment, interwiki)
         namespace = ns.id,
         id = id,
         interwiki = interwiki or "",
-        fragment = fragment,
+        fragment = fragment or "",
         nsText = ns.name ~= "Main" and ns.name or "",
         subjectNsText = (ns.subject or ns).name,
         text = title,


### PR DESCRIPTION
Align with Scribunto, fix nil Lua error at en module "template link" line 43.

Example page: Nihilarian