### PR TITLE
Call `Wtp.preprocess_text()` again after calling `Wtp.expand()` in `Wtp.parse()`

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -1985,6 +1985,7 @@ class Wtp:
             text = self.expand(
                 text, template_fn=template_fn, post_template_fn=post_template_fn
             )
+            text = self.preprocess_text(text)
             # print(f"PARSE EXPAND ALL: {text=!r}")
         elif pre_expand or additional_expand:
             text = self.expand(
@@ -1995,6 +1996,7 @@ class Wtp:
                 template_fn=template_fn,
                 post_template_fn=post_template_fn,
             )
+            text = self.preprocess_text(text)
 
         # print("parse:", repr(text))
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2932,6 +2932,21 @@ def foo(x):
             {1: "en", 2: "—hole", 3: "----hole"},
         )
 
+    def test_nowiki_in_html_attr_value(self):
+        # https://pl.wiktionary.org/wiki/Szablon:skrót/szkielet
+        # used in etymology template https://pl.wiktionary.org/wiki/Szablon:etym
+        self.ctx.start_page("pies")
+        self.ctx.add_page(
+            "Template:skrót/szkielet",
+            10,
+            '<span class="short-container<nowiki/> ">text</span>',
+        )
+        root = self.ctx.parse("{{skrót/szkielet}}", expand_all=True)
+        self.assertEqual(len(root.children), 1)
+        span_node = root.children[0]
+        self.assertIsInstance(span_node, HTMLNode)
+        self.assertEqual(span_node.tag, "span")
+
 
 # XXX implement <nowiki/> marking for links, templates
 #  - https://en.wikipedia.org/wiki/Help:Wikitext#Nowiki


### PR DESCRIPTION
Template could contain `<nowiki/>` tag and needs to be converted, otherwise the `<span>` tag is parsed as text but not `HTMLNode`.

Find the bug in pl edition "etym" template.