### PR TITLE
Don't add empty argument to parser functions in `to_wikitext()`

### DIFF
--- a/src/wikitextprocessor/node_expand.py
+++ b/src/wikitextprocessor/node_expand.py
@@ -121,7 +121,12 @@ def to_wikitext(
             parts.append("|".join(map(recurse, node.largs)))
             parts.append("}}}")
         elif kind == NodeKind.PARSER_FN:
-            parts.append("{{" + recurse(node.largs[0]) + ":")
+            first_part = "{{" + recurse(node.largs[0])
+            if len(node.largs) > 1:
+                # extra empty arg could affect expand result
+                # only add ":" if parser function has args
+                first_part += ":"
+            parts.append(first_part)
             parts.append("|".join(map(recurse, node.largs[1:])))
             parts.append("}}")
         elif kind == NodeKind.URL:

--- a/tests/test_node_expand.py
+++ b/tests/test_node_expand.py
@@ -131,7 +131,7 @@ class NodeExpTests(unittest.TestCase):
         self.backcvt("{{#expr:1+{{v}}}}", "{{#expr:1+{{v}}}}")
 
     def test_parserfn3(self):
-        self.backcvt("{{ROOTPAGENAME}}", "{{ROOTPAGENAME:}}")
+        self.backcvt("{{ROOTPAGENAME}}", "{{ROOTPAGENAME}}")
 
     def test_url1(self):
         self.backcvt("[https://wikipedia.org]", "[https://wikipedia.org]")
@@ -302,3 +302,9 @@ class NodeExpTests(unittest.TestCase):
         self.ctx.add_page("Template:test", 10, "{{{1||}}}")
         self.assertEqual(self.ctx.expand("{{test|t}}"), "t")
         self.assertEqual(len(self.ctx.debugs), 0)
+
+    def test_do_not_add_empty_arg_to_parser_function(self):
+        # {{PAGENAME:}} expands to ""
+        self.ctx.start_page("test_title")
+        root = self.ctx.parse("{{PAGENAME}}")
+        self.assertEqual(self.ctx.node_to_html(root.children[0]), "test_title")


### PR DESCRIPTION
wiktextract code `clean_node()` calls `Wtp.node_to_html()` and finally to `to_wikitext()`.

This function converts `{{PAGENAME}}` to `{{PAGENAME:}}`, and the second form expands to empty string but not page title.

Find this error when fixing ja edition exceptions.

All wiktextract tests passed.