### PR TITLE
Implement `mw.loadJsonData()`

### DIFF
--- a/src/wikitextprocessor/lua/_sandbox_phase1.lua
+++ b/src/wikitextprocessor/lua/_sandbox_phase1.lua
@@ -144,6 +144,16 @@ local function new_loadData(modname)
     return ret
 end
 
+local function new_loadJsonData(page)
+    if loaddata_cache[page] ~= nil then
+        return loaddata_cache[page]
+    end
+    local json_str = _python_loader(page)
+    local json_data = mw_jsondecode_python(json_str, 0)
+    loaddata_cache[page] = json_data
+    return json_data
+end
+
 -- We don't use the default require. Disable its paths too.
 package.searchers = {}
 package.searchers[0] = nil
@@ -436,6 +446,7 @@ local function _lua_reset_env()
     env["_orig_next"] = _orig_next
     env["_orig_insert"] = _orig_insert
     env["_new_loadData"] = new_loadData
+    env["_new_loadJsonData"] = new_loadJsonData
     env["_new_loader"] = new_loader
     env["_cached_mod"] = _cached_mod
     env["_save_mod"] = _save_mod

--- a/src/wikitextprocessor/lua/_sandbox_phase2.lua
+++ b/src/wikitextprocessor/lua/_sandbox_phase2.lua
@@ -155,7 +155,7 @@ local function _lua_invoke(mod_name, fn_name, frame, page_title, timeout)
             success, mod = pcall(initfn)
             if not success then
                 return false, ("\tLoading module failed in #invoke: " ..
-                    mod_name .. "\n" .. mod)
+                               mod_name .. "\n" .. tostring(mod))
             end
             _save_mod(mod_name, mod)
         else

--- a/src/wikitextprocessor/lua/mw.lua
+++ b/src/wikitextprocessor/lua/mw.lua
@@ -100,6 +100,10 @@ function mw.loadData(modname)
     return _new_loadData(modname)
 end
 
+function mw.loadJsonData(page)
+    return _new_loadJsonData(page)
+end
+
 function mw.log(...)
     -- print("mw.log", ...)
 end

--- a/src/wikitextprocessor/luaexec.py
+++ b/src/wikitextprocessor/luaexec.py
@@ -312,6 +312,9 @@ def set_lua_env_funcs(lua, wtp):
     set_global_lua_variable(
         lua, "_python_top_env", partial(top_lua_stack, wtp.lua_env_stack)
     )
+    set_global_lua_variable(
+        lua, "mw_jsondecode_python", partial(mw_text_jsondecode, wtp)
+    )
 
 
 def initialize_lua(ctx: "Wtp") -> None:

--- a/tests/test_lua.py
+++ b/tests/test_lua.py
@@ -520,3 +520,21 @@ return "Configuration"
             self.wtp.expand("{{#invoke:Citation/CS1|citation}}"),
             "Configuration",
         )
+
+    def test_mw_load_json_data(self):
+        self.wtp.add_page(
+            "Module:test.json", 828, '{"key": "value"}', model="json"
+        )
+        self.wtp.add_page(
+            "Module:test",
+            828,
+            """local export = {}
+function export.test(frame)
+  local data = mw.loadJsonData('Module:test.json')
+  return data["key"]
+end
+return export""",
+            model="Scribunto",
+        )
+        self.wtp.start_page("")
+        self.assertEqual(self.wtp.expand("{{#invoke:test|test}}"), "value")


### PR DESCRIPTION
Used in https://pl.wiktionary.org/wiki/Moduł:transliterator

The `tostring(mod)` change is for fixing `attempt to concatenate lcoal 'mod' (a userdata value)` Lua error at that line.