### PR TITLE
Only parse external link as text if `<nowiki/>` directly after `[`

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -767,7 +767,11 @@ class Wtp:
         def repl_extlink(m: re.Match) -> CookieChar:
             """Replacement function for external links [...].  This is also
             used to replace bracketed sections, such as [...]."""
-            nowiki = MAGIC_NOWIKI_CHAR in m.group(0)
+
+            # parse as text if <nowiki/> tag at the start
+            nowiki = (
+                re.match(r"\[\s*" + MAGIC_NOWIKI_CHAR, m.group(0)) is not None
+            )
             orig = m.group(1)
             if not orig.startswith(URL_STARTS):
                 return MAGIC_LBRACKET_CHAR + orig + MAGIC_RBRACKET_CHAR

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2947,6 +2947,21 @@ def foo(x):
         self.assertIsInstance(span_node, HTMLNode)
         self.assertEqual(span_node.tag, "span")
 
+    def test_nowiki_tag_in_external_link(self):
+        # https://zh.wiktionary.org/wiki/Template:RQ:Qur'an
+        self.ctx.start_page("محمد")
+        root = self.ctx.parse("[https://quran.com/3/144 3<nowiki/>:144]")
+        url_node = root.children[0]
+        self.assertIsInstance(url_node, WikiNode)
+        self.assertEqual(url_node.kind, NodeKind.URL)
+        self.assertEqual(
+            url_node.largs, [["https://quran.com/3/144"], ["3<nowiki />:144"]]
+        )
+
+        root = self.ctx.parse("[ <nowiki/> https://quran.com/3/144 3:144]")
+        text_node = root.children[0]
+        self.assertEqual(text_node, "[ <nowiki /> ")
+
 
 # XXX implement <nowiki/> marking for links, templates
 #  - https://en.wikipedia.org/wiki/Help:Wikitext#Nowiki


### PR DESCRIPTION
Put `<nowiki/>` at any other place expands to normal external url link.