### PR TITLE
Support upper case `#default` branch in `#switch` parser function

### DIFF
--- a/src/wikitextprocessor/parserfns.py
+++ b/src/wikitextprocessor/parserfns.py
@@ -122,7 +122,7 @@ def switch_fn(
         k = expander(k).strip()
         if k == val or match_next:
             return expander(v).strip()
-        if k == "#default":
+        if k.lower() == "#default":
             defval = v
         last = None
     if defval is not None:


### PR DESCRIPTION
It is used in ja edition template:
https://ja.wiktionary.org/wiki/テンプレート:en-noun