### PR TITLE
Node to wikitext

### DIFF
--- a/src/wikitextprocessor/node_expand.py
+++ b/src/wikitextprocessor/node_expand.py
@@ -95,12 +95,8 @@ def to_wikitext(
             parts.append(recurse(node.children))
         elif kind == NodeKind.LIST_ITEM:
             parts.append(node.sarg)
-            prev_list = False
             for x in node.children:
-                if prev_list:
-                    parts.append(node.sarg + ":")
                 parts.append(recurse(x))
-                prev_list = isinstance(x, WikiNode) and x.kind == NodeKind.LIST
         elif kind == NodeKind.PRE:
             parts.append("<pre>")
             parts.append(recurse(node.children))

--- a/src/wikitextprocessor/parser.py
+++ b/src/wikitextprocessor/parser.py
@@ -2341,20 +2341,43 @@ def parse_encoded(ctx: "Wtp", text: str) -> WikiNode:
     return ret
 
 
-def print_tree(tree: Union[str, WikiNode], indent: int = 0) -> None:
+@overload
+def print_tree(
+    tree: Union[str, WikiNode], indent: int, ret_value: Literal[True]
+) -> str: ...
+
+@overload
+def print_tree(
+    tree: Union[str, WikiNode], indent: int = ..., ret_value: Literal[False]=...
+) -> None: ...
+
+def print_tree(
+    tree: Union[str, WikiNode], indent: int = 0, ret_value=False
+) -> Optional[str]:
     """Prints the parse tree for debugging purposes.  This does not expand
     HTML entities; that should be done after processing templates."""
     assert isinstance(tree, (WikiNode, str))
     assert isinstance(indent, int)
+    parts = []
     if isinstance(tree, str):
-        print("{}{}".format(" " * indent, repr(tree)))
-        return
-    print(
+        parts.append("{}{}".format(" " * indent, repr(tree)))
+        if ret_value:
+            return "\n".join(parts)
+        else:
+            print("\n".join(parts))
+    assert isinstance(tree, WikiNode)
+    parts.append(
         "{}{} {}".format(
             " " * indent, tree.kind.name, tree.sarg if tree.sarg else tree.largs
         )
     )
     for k, v in tree.attrs.items():
-        print("{}    {}={}".format(" " * indent, k, v))
+        parts.append("{}    {}={}".format(" " * indent, k, v))
     for child in tree.children:
-        print_tree(child, indent + 2)
+        parts.append(print_tree(child, indent + 2, ret_value=True))
+
+    if ret_value:
+        return "\n".join(parts)
+    else:
+        print("\n".join(parts))
+        return None

--- a/src/wikitextprocessor/parser.py
+++ b/src/wikitextprocessor/parser.py
@@ -2346,10 +2346,14 @@ def print_tree(
     tree: Union[str, WikiNode], indent: int, ret_value: Literal[True]
 ) -> str: ...
 
+
 @overload
 def print_tree(
-    tree: Union[str, WikiNode], indent: int = ..., ret_value: Literal[False]=...
+    tree: Union[str, WikiNode],
+    indent: int = ...,
+    ret_value: Literal[False] = ...,
 ) -> None: ...
+
 
 def print_tree(
     tree: Union[str, WikiNode], indent: int = 0, ret_value=False

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2962,6 +2962,21 @@ def foo(x):
         text_node = root.children[0]
         self.assertEqual(text_node, "[ <nowiki /> ")
 
+    def test_clean_node_lists(self):
+        wikitext = """
+# line 1
+## line 2
+#: example 1
+#: example 2
+    """
+        self.ctx.start_page("test")
+        tree = self.ctx.parse(wikitext)
+        print(tree)
+        # cleaned = clean_node(self.wxr, None, tree)
+        cleaned = self.ctx.node_to_wikitext(tree)
+        print(cleaned)
+        self.assertEqual(cleaned, wikitext)
+
 
 # XXX implement <nowiki/> marking for links, templates
 #  - https://en.wikipedia.org/wiki/Help:Wikitext#Nowiki


### PR DESCRIPTION
When parsing lists, Wtp.node_to_wikitext will not reverse the transformation correctly:

```
# line 1
## line 2
#: example 1
#: example 2
```

becomes:

```
# line 1
## line 2
#:#: example 1
#: example 2
```

This seems like the result of a really old kludge that seems unnecessary now. I think WikiNode has changed between now-and-then, and the prefix of the line might have been explicitly added to only later so the old code wasn't update and there was an extra kludge inserting "#"+":" when two lists were next to each other (as in when you have a line starting with "#" followed by ":", for example; same depth, different lists).