### PR TITLE
Return empty string for `{{ns:0}}` and `{{ns:}}`

### DIFF
--- a/src/wikitextprocessor/parserfns.py
+++ b/src/wikitextprocessor/parserfns.py
@@ -740,6 +740,8 @@ def ns_fn(
     https://www.mediawiki.org/wiki/Help:Magic_words#Namespaces_2
     """
     arg = expander(args[0]).strip() if args else ""
+    if arg in ["0", ""]:
+        return ""
     lc_arg = arg.lower()
     for key, ns in wtp.NAMESPACE_DATA.items():
         if arg.isdigit() and ns["id"] == int(arg):

--- a/tests/test_parserfns.py
+++ b/tests/test_parserfns.py
@@ -191,3 +191,9 @@ class TestParserFunctions(TestCase):
         for wikitext, result in test_cases:
             with self.subTest(wikitext=wikitext, result=result):
                 self.assertEqual(self.wtp.expand(wikitext), result)
+
+    def test_ns_empty_str(self):
+        # https://ru.wiktionary.org/wiki/Шаблон:--lang--
+        self.wtp.start_page("test")
+        self.assertEqual(self.wtp.expand("{{ns:0}}"), "")
+        self.assertEqual(self.wtp.expand("{{ns:}}"), "")


### PR DESCRIPTION
This is required in ru edition's language title template "--lang--" to create language category link.