### PR TITLE
Handle includeonly elements

### DIFF
--- a/tests/test_dumpparser.py
+++ b/tests/test_dumpparser.py
@@ -53,3 +53,6 @@ class DumpParserTests(unittest.TestCase):
             {0, 4, 10, 14, 100, 110, 118, 828},
         )
         self.assertGreater(self.wtp.saved_page_nums(), 0)
+
+    def test_removing_includeonly(self):
+        ...


### PR DESCRIPTION
Fixes #314

Apparently <includeonly> (which renders text only when used as a template (transcluded), not when showing the template's own page so that these pages don't get
stuff like wrong categories) has some weird whitespace trimming rules.

1. If there's a newline before the end tag, return everything and add a space (because this causes a PRE block to appear??)
2. Otherwise, if there's only links or other things that render as whitespace strip all the whitespace.
3. If there's other text, only strip away the whitespace that is after that text, ignoring category links.