### PR TITLE
Only parse section node if the token is at the beginning of a line 

### DIFF
--- a/src/wikitextprocessor/node_expand.py
+++ b/src/wikitextprocessor/node_expand.py
@@ -28,7 +28,8 @@ if TYPE_CHECKING:
 
 NodeHandlerFnCallable = Callable[[WikiNode], Union[None, GeneralNode]]
 
-kind_to_level: dict[NodeKind, str] = {
+KIND_TO_LEVEL: dict[NodeKind, str] = {
+    NodeKind.LEVEL1: "=",
     NodeKind.LEVEL2: "==",
     NodeKind.LEVEL3: "===",
     NodeKind.LEVEL4: "====",
@@ -83,8 +84,8 @@ def to_wikitext(
 
         kind = node.kind
         parts: list[str] = []
-        if kind in kind_to_level:
-            tag = kind_to_level[kind]
+        if kind in KIND_TO_LEVEL:
+            tag = KIND_TO_LEVEL[kind]
             t = recurse(node.largs)  # This is where WikiNodeListArgs is needed
             # if you were wondering...
             parts.append("\n{} {} {}\n".format(tag, t, tag))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2992,9 +2992,21 @@ text
         second_arg_list = template.template_parameters.get("contenu2")
         self.assertEqual(len(second_arg_list), 2)
         heading_node = second_arg_list[1]
-        self.assertIsInstance(heading_node, WikiNode)
+        self.assertIsInstance(heading_node, LevelNode)
         self.assertEqual(heading_node.kind, NodeKind.LEVEL3)
+        self.assertEqual(heading_node.children, ["\ntext\n"])
         self.assertEqual(template.template_parameters.get("contenu3"), "3")
+
+    def test_section_wikitext_in_link(self):
+        # https://zh.wiktionary.org/wiki/≠
+        # should be parsed as plain text
+        self.ctx.start_page("≠")
+        tree = self.ctx.parse("[[=/=]]")
+        self.assertEqual(len(tree.children), 1)
+        link_node = tree.children[0]
+        self.assertIsInstance(link_node, WikiNode)
+        self.assertEqual(link_node.kind, NodeKind.LINK)
+        self.assertEqual(link_node.largs, [["=/="]])
 
 
 # XXX implement <nowiki/> marking for links, templates


### PR DESCRIPTION
Fix zh edition exception: https://kaikki.org/zhwiktionary/errors/details-----EXCEPTION-while-parsing-page-----i-YTyJLi-P.html