### PR TITLE
Implement "int" parser function

### DIFF
--- a/src/wikitextprocessor/parserfns.py
+++ b/src/wikitextprocessor/parserfns.py
@@ -1646,6 +1646,17 @@ def rel2abs_fn(
     return str(path.resolve()).removeprefix("/")
 
 
+def int_fn(
+    wtp: "Wtp", fn_name: str, args: list[str], expander: Callable[[str], str]
+) -> str:
+    # https://www.mediawiki.org/wiki/Help:Magic_words#Localization
+    if wtp.project == "wiktionary" and len(args) > 0 and args[0] == "lang":
+        return wtp.lang_code
+    if len(args) > 0 and len(args[0]) > 0:
+        return f"⧼{args[0]}⧽"
+    return f"[[:{wtp.LOCAL_NS_NAME_BY_ID.get(10, '')}:int:]]"
+
+
 # This list should include names of predefined parser functions and
 # predefined variables (some of which can take arguments using the same
 # syntax as parser functions and we treat them as parser functions).
@@ -1797,6 +1808,7 @@ PARSER_FUNCTIONS = {
     "#trecho-x": unimplemented_fn,
     "#section-x": unimplemented_fn,
     "#language": language_fn,
+    "int": int_fn,
 }
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1446,15 +1446,6 @@ def foo(x):
         self.assertEqual(d.children, [])
         self.assertEqual(b.largs[1], ["bar"])
 
-    def test_template8(self):
-        # Namespace specifiers, e.g., {{int:xyz}} should not generate
-        # parser functions
-        tree = self.parse("test", "{{int:xyz}}")
-        self.assertEqual(len(tree.children), 1)
-        b = tree.children[0]
-        self.assertEqual(b.kind, NodeKind.TEMPLATE)
-        self.assertEqual(b.largs, [["int:xyz"]])
-
     def test_template9(self):
         # Main namespace references, e.g., {{:xyz}} should not
         # generate parser functions

--- a/tests/test_parserfns.py
+++ b/tests/test_parserfns.py
@@ -197,3 +197,13 @@ class TestParserFunctions(TestCase):
         self.wtp.start_page("test")
         self.assertEqual(self.wtp.expand("{{ns:0}}"), "")
         self.assertEqual(self.wtp.expand("{{ns:}}"), "")
+
+    def test_int(self):
+        # https://nl.wiktionary.org/wiki/Module:ISOdate
+        self.wtp.start_page("test")
+        self.wtp.project = "wiktionary"
+        self.wtp.lang_code = "nl"
+        self.assertEqual(self.wtp.expand("{{int:lang}}"), "nl")
+        self.wtp.project = "wikipedia"
+        self.assertEqual(self.wtp.expand("{{int:lang}}"), "⧼lang⧽")
+        self.assertEqual(self.wtp.expand("{{int:}}"), "[[:Template:int:]]")


### PR DESCRIPTION
It's used in Dutch Wiktionary's "ISOdate" Lua module, return language code for `{{int:lang}}` in a Wiktionary project.