### PR TITLE
[nl] Change 'ref' HTML 'category' to '*'

### DIFF
--- a/src/wikitextprocessor/wikihtml.py
+++ b/src/wikitextprocessor/wikihtml.py
@@ -137,7 +137,7 @@ ALLOWED_HTML_TAGS: dict[str, HTMLTagData] = {
         "close-next": ["rt", "rtc", "rp", "rb"],
         "content": ["phrasing"],
     },
-    "ref": {"parents": ["phrasing"], "content": ["phrasing"]},
+    "ref": {"parents": ["*"], "content": ["*"]},
     "references": {
         "parents": ["flow"],
         # "no-end-tag": True,

--- a/src/wikitextprocessor/wikihtml.py
+++ b/src/wikitextprocessor/wikihtml.py
@@ -59,7 +59,7 @@ ALLOWED_HTML_TAGS: dict[str, HTMLTagData] = {
     },
     "del": {"parents": ["phrasing"], "content": ["phrasing"]},
     "dfn": {"parents": ["phrasing"], "content": ["phrasing"]},
-    "div": {"parents": ["phrasing", "dl"], "content": ["flow"]},
+    "div": {"parents": ["flow", "dl"], "content": ["flow"]},
     "dl": {"parents": ["flow"], "content": ["flow"]},
     "dt": {
         "parents": ["dl", "div"],

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2999,6 +2999,18 @@ text
         self.assertEqual(link_node.kind, NodeKind.LINK)
         self.assertEqual(link_node.largs, [["=/="]])
 
+    def test_div_in_ref_tag(self):
+        # https://nl.wiktionary.org/wiki/Sjabloon:citeer
+        self.ctx.start_page("")
+        root = self.ctx.parse("<ref><div>text</div></ref>")
+        self.assertEqual(len(root.children), 1)
+        ref_tag = root.children[0]
+        self.assertIsInstance(ref_tag, HTMLNode)
+        self.assertEqual(ref_tag.tag, "ref")
+        div_tag = ref_tag.children[0]
+        self.assertIsInstance(div_tag, HTMLNode)
+        self.assertEqual(div_tag.tag, "div")
+
 
 # XXX implement <nowiki/> marking for links, templates
 #  - https://en.wikipedia.org/wiki/Help:Wikitext#Nowiki

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2999,18 +2999,6 @@ text
         self.assertEqual(link_node.kind, NodeKind.LINK)
         self.assertEqual(link_node.largs, [["=/="]])
 
-    def test_div_in_ref_tag(self):
-        # https://nl.wiktionary.org/wiki/Sjabloon:citeer
-        self.ctx.start_page("")
-        root = self.ctx.parse("<ref><div>text</div></ref>")
-        self.assertEqual(len(root.children), 1)
-        ref_tag = root.children[0]
-        self.assertIsInstance(ref_tag, HTMLNode)
-        self.assertEqual(ref_tag.tag, "ref")
-        div_tag = ref_tag.children[0]
-        self.assertIsInstance(div_tag, HTMLNode)
-        self.assertEqual(div_tag.tag, "div")
-
 
 # XXX implement <nowiki/> marking for links, templates
 #  - https://en.wikipedia.org/wiki/Help:Wikitext#Nowiki


### PR DESCRIPTION
Continued from PR #321

There are a few wikitext-specific "HTML-looking" tags like `includeonly` that have "*" as their category, allowing them to be used anywhere in the text.

Co-authored by: xxyzz <gitpull@protonmail.com>