### PR TITLE
find_html: allow list of tags to find.

### DIFF
--- a/src/wikitextprocessor/parser.py
+++ b/src/wikitextprocessor/parser.py
@@ -496,7 +496,7 @@ class WikiNode:
     @overload
     def find_html(
         self,
-        target_tag: str,
+        target_tags: str | list[str],
         with_index: Literal[True],
         attr_name: str,
         attr_value: str,
@@ -505,7 +505,7 @@ class WikiNode:
     @overload
     def find_html(
         self,
-        target_tag: str,
+        target_tags: str | list[str],
         with_index: Literal[False] = ...,
         attr_name: str = ...,
         attr_value: str = ...,
@@ -513,7 +513,7 @@ class WikiNode:
 
     def find_html(
         self,
-        target_tag: str,
+        target_tags: str | list[str],
         with_index: bool = False,
         attr_name: str = "",
         attr_value: str = "",
@@ -523,7 +523,9 @@ class WikiNode:
             if TYPE_CHECKING:
                 assert isinstance(node, HTMLNode)
             # node.tag is an alias for node.sarg defined in HTMLNode
-            if node.tag == target_tag:
+            if isinstance(target_tags, str):
+                target_tags = [target_tags]
+            if node.tag in target_tags:
                 if len(attr_name) > 0 and attr_value not in node.attrs.get(
                     attr_name, {}
                 ):


### PR DESCRIPTION
To make find_html work the same was as find_child, allow `target_tag` (now `target_tags`) to be a list of strings instead of a single string, and return
all HTML element children with one of those tags.