### PR TITLE
Implement `mw.wikibase.getSitelink()`

### DIFF
--- a/src/wikitextprocessor/lua/mw_wikibase.lua
+++ b/src/wikitextprocessor/lua/mw_wikibase.lua
@@ -41,7 +41,7 @@ function mw_wikibase.getLabelByLang(id, languageCode)
 end
 
 function mw_wikibase.getSitelink(id, globalSiteId)
-   return nil
+    return mw_wikibase_getSitelink_py(id, globalSiteId)
 end
 
 function mw_wikibase.getDescription(id)

--- a/src/wikitextprocessor/luaexec.py
+++ b/src/wikitextprocessor/luaexec.py
@@ -251,7 +251,7 @@ def mw_language_format_date_python(
 def call_set_functions(
     ctx: "Wtp", set_functions: Callable[["_LuaTable"], None]
 ) -> None:
-    from .wikidata import mw_wikibase_getEntity
+    from .wikidata import mw_wikibase_getEntity, mw_wikibase_getSitelink
 
     assert ctx.lua is not None
     # Set functions that are implemented in Python
@@ -289,6 +289,9 @@ def call_set_functions(
                     mw_language_format_date_python, ctx
                 ),
                 "mw_wikibase_getEntity_py": partial(mw_wikibase_getEntity, ctx),
+                "mw_wikibase_getSitelink_py": partial(
+                    mw_wikibase_getSitelink, ctx
+                ),
             }
         )
     )

--- a/src/wikitextprocessor/wikidata.py
+++ b/src/wikitextprocessor/wikidata.py
@@ -391,3 +391,13 @@ def mw_wikibase_getEntity(wtp: "Wtp", item_id: Optional[str]) -> Any:
     if entity_data is None or wtp.lua is None:
         return None
     return wtp.lua.table_from(entity_data, recursive=True)  # type:ignore
+
+
+def mw_wikibase_getSitelink(
+    wtp: "Wtp", item_id: str, globalSiteId: str | None
+) -> str | None:
+    entity_data = get_entity_data(wtp, item_id)
+    if entity_data is None:
+        return None
+    site_id = globalSiteId or wtp.lang_code + wtp.project
+    return entity_data.get("sitelinks", {}).get(site_id, {}).get("title", "")

--- a/tests/test_lua.py
+++ b/tests/test_lua.py
@@ -538,3 +538,35 @@ return export""",
         )
         self.wtp.start_page("")
         self.assertEqual(self.wtp.expand("{{#invoke:test|test}}"), "value")
+
+    @patch(
+        "requests.get",
+        return_value=MockRequests(
+            True,
+            {
+                "entities": {
+                    "Q37041": {
+                        "id": "Q37041",
+                        "sitelinks": {"kowiki": {"title": "한문"}},
+                    }
+                }
+            },
+        ),
+    )
+    def test_wikidata_getsitelink(self, mock_request):
+        self.wtp.add_page(
+            "Module:test",
+            828,
+            """
+local export = {}
+function export.test(frame)
+  local a = mw.wikibase.getSitelink("Q37041", "kowiki")
+  local b = mw.wikibase.getSitelink("Q37041", "kowiki")
+  return a .. b
+end
+return export""",
+            model="Scribunto",
+        )
+        self.wtp.start_page("")
+        self.assertEqual(self.wtp.expand("{{#invoke:test|test}}"), "한문한문")
+        mock_request.assert_called_once()


### PR DESCRIPTION
Fix Lua error in ko edition "bor" template, Lua module "languages", page "병신".

Add `print` in Lua pages to find error is really nerve-racking...