### PR TITLE
Fix `AttributeError` in nl edition page "aanbalken"

### DIFF
--- a/src/wikitextprocessor/parser.py
+++ b/src/wikitextprocessor/parser.py
@@ -634,7 +634,11 @@ class TemplateNode(WikiNode):
                                 )
                             continue
 
-                if is_named and len(parameter_name) > 0:  # type: ignore
+                if (
+                    is_named
+                    and isinstance(parameter_name, str)
+                    and len(parameter_name) > 0
+                ) or isinstance(parameter_name, int):
                     parameters[parameter_name].append(parameter)
                 else:
                     parameters[unnamed_parameter_index].append(parameter)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3011,6 +3011,18 @@ text
         self.assertIsInstance(div_tag, HTMLNode)
         self.assertEqual(div_tag.tag, "div")
 
+    def test_named_number_template_param(self):
+        # https://nl.wiktionary.org/wiki/aanbalken
+        self.ctx.start_page("aanbalken")
+        root = self.ctx.parse(
+            "{{-nlstam-|{{pn}}|[[balkte aan]]|[[aangebalkt]]|||scheid=s||7={{nlzwak-t}}}}"  # noqa: E501
+        )
+        t_node = root.children[0]
+        self.assertIsInstance(t_node, TemplateNode)
+        param = t_node.template_parameters[7]
+        self.assertIsInstance(param, TemplateNode)
+        self.assertEqual(param.template_name, "nlzwak-t")
+
 
 # XXX implement <nowiki/> marking for links, templates
 #  - https://en.wikipedia.org/wiki/Help:Wikitext#Nowiki


### PR DESCRIPTION
Error message: `AttributeError: 'str' object has no attribute 'append'` https://kaikki.org/nlwiktionary/errors/details-----EXCEPTION-while-parsing-page--aanb-R-~wgGCv.html

"7={{template}}" parameter doesn't increase `unnamed_parameter_index` variable, should use the changed `int` type `parameter_name` variable to add its value.