### PR TITLE
Don't treat nested template in template parameters as expansion loop

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -1925,13 +1925,17 @@ class Wtp:
 
 
 def detect_expand_template_loop(stack: list[str]) -> bool:
+    # return `True` if find repeat pattern in expand stack
+    # GH issue tatuylonen/wiktextract#894
     stack_len = len(stack)
     if stack_len < 2 or stack[-1] not in stack[:-1]:
         return False
-    for size in range(1, stack_len // 2 + 1):
-        for i in range(stack_len - size):
-            if (stack_len - i) % size == 0:
-                pattern = stack[i : i + size]
-                if pattern * ((stack_len - i) // size) == stack[i:]:
+    for pattern_size in range(1, stack_len // 2 + 1):
+        for i in range(stack_len - pattern_size):
+            if (stack_len - i) % pattern_size == 0:
+                pattern = stack[i : i + pattern_size]
+                if pattern[0].startswith("ARGVAL-"):
+                    continue
+                if pattern * ((stack_len - i) // pattern_size) == stack[i:]:
                     return True
     return False

--- a/tests/test_wikiprocess.py
+++ b/tests/test_wikiprocess.py
@@ -4276,6 +4276,17 @@ return export""",
             "[[:Template:m]]</strong>",
         )
 
+    def test_nested_template_in_template_args(self):
+        # used in nl edition language title templates
+        self.ctx.add_page(
+            "Template:str len",
+            10,
+            """{{str len/core|{{str len/core|{{str len/core|{{{1}}}}}}}}}""",
+        )
+        self.ctx.add_page("Template:str len/core", 10, """{{{1}}}""")
+        self.ctx.start_page("doodgeboren")
+        self.assertEqual(self.ctx.expand("{{str len|a}}"), "a")
+
 
 # XXX Test template_fn
 


### PR DESCRIPTION
also find this false positive bug in en edition's [quote-song](https://en.wiktionary.org/wiki/Template:quote-song) template, it has some nested "ifmatch" templates.