### PR TITLE
Load Lua module namesapce page not standard library for `#invoke`

### DIFF
--- a/src/wikitextprocessor/luaexec.py
+++ b/src/wikitextprocessor/luaexec.py
@@ -410,6 +410,9 @@ def call_lua_sandbox(
 
     # Get module and function name
     modname = expander(invoke_args[0]).strip()
+    module_ns_prefix = ctx.NAMESPACE_DATA["Module"]["name"] + ":"
+    if not modname.startswith(module_ns_prefix):
+        modname = module_ns_prefix + modname
     modfn = expander(invoke_args[1]).strip()
 
     def make_frame(
@@ -752,10 +755,8 @@ def call_lua_sandbox(
     msg = "Lua execution error"
     if "Lua timeout error" in text:
         msg = "Lua timeout error"
-    return (
-        '<strong class="error">{} in Module:{} function {}' "</strong>".format(
-            msg, html.escape(modname), html.escape(modfn)
-        )
+    return '<strong class="error">{} in {} function {}' "</strong>".format(
+        msg, html.escape(modname), html.escape(modfn)
     )
 
 

--- a/tests/test_lua.py
+++ b/tests/test_lua.py
@@ -570,3 +570,17 @@ return export""",
         self.wtp.start_page("")
         self.assertEqual(self.wtp.expand("{{#invoke:test|test}}"), "한문한문")
         mock_request.assert_called_once()
+
+    def test_math_module_sum(self):
+        # load "Module:math" not Lua's math library
+        self.wtp.start_page("sea")
+        self.wtp.add_page(
+            "Module:math",
+            828,
+            """local export = {}
+function export.sum(frame)
+  return 1
+end
+return export""",
+        )
+        self.assertEqual(self.wtp.expand("{{#invoke:math|sum}}"), "1")

--- a/tests/test_wikiprocess.py
+++ b/tests/test_wikiprocess.py
@@ -2221,7 +2221,7 @@ return export
         )
         self.ctx.start_page("Tt")
         ret = self.ctx.expand("{{testtempl|{{testtempl2|zz}}|yy}}")
-        self.assertEqual(ret, "testmod")
+        self.assertEqual(ret, "Module:testmod")
 
     def test_frame_parent8(self):
         self.ctx.add_page(


### PR DESCRIPTION
Fix Lua error in [Template:R:gem:HGE](https://en.wiktionary.org/wiki/Template:R:gem:HGE), Lua's math library doesn't have `sum` function, should load "Module:math".