### PR TITLE
`<ref>` should ignore whitespace preformatted lines

### DIFF
--- a/src/wikitextprocessor/parser.py
+++ b/src/wikitextprocessor/parser.py
@@ -967,7 +967,14 @@ def text_fn(ctx: "Wtp", token: str) -> None:
             ):
                 return
             # print(f"{token=}")
-            if node.kind != NodeKind.PREFORMATTED and not ctx.pre_parse:
+            if (
+                node.kind != NodeKind.PREFORMATTED
+                and not ctx.pre_parse
+                and not any(  # GH issue #336
+                    isinstance(n, HTMLNode) and n.tag in ["ref", "p"]
+                    for n in ctx.parser_stack
+                )
+            ):
                 node = _parser_push(ctx, NodeKind.PREFORMATTED)
 
     # If the previous child was a link that doesn't yet have children,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1290,6 +1290,18 @@ foo
         self.assertEqual(len(tree.children), 1)
         self.assertEqual(tree.children[0], "\nfoo\n")
 
+    def test_ref_ignores_pre(self):
+        # GH issue #336
+        tree = self.parse(
+            "test",
+            """<ref>
+ foo</ref>""",
+        )
+        ref_node = tree.children[0]
+        self.assertIsInstance(ref_node, HTMLNode)
+        self.assertEqual(ref_node.tag, "ref")
+        self.assertEqual(ref_node.children, ["\n foo"])
+
     def test_pre1(self):
         tree = self.parse(
             "test",


### PR DESCRIPTION
Fixes second part of #336

When we would normally be pushing a layer of NodeKind.PREFORMATTED, check if the stack has any HTML-elements with the `<ref>` tag and if that is the case don't push PREFORMATTED.

If other HTML-like tags need this in the future (onlyinclude? includeonly??) then this is the place where to add those checks.

Looking through the stack could be better. Filter? Any? Oh yeah, duh.