### PR TITLE
Remove new line characters directly after wikitext comment

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -1096,7 +1096,7 @@ class Wtp:
             r"(?si)<nowiki\s*>(.*?)</nowiki\s*>", _nowiki_sub_fn, text
         )
         text = re.sub(r"(?si)<nowiki\s*/>", MAGIC_NOWIKI_CHAR, text)
-        text = re.sub(r"(?s)<!--.*?-->", "", text)
+        text = re.sub(r"(?s)<!--.*?-->\n*", "", text)
         # print("PREPROCESSED_TEXT: {!r}".format(text))
         return text
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3046,6 +3046,16 @@ text
         self.assertIsInstance(param, TemplateNode)
         self.assertEqual(param.template_name, "nlzwak-t")
 
+    def test_comment_between_lists(self):
+        # GH issue tatuylonen/wiktextract#912
+        self.ctx.start_page("agnathia")
+        root = self.ctx.parse("""# list 1
+<!-- comment -->
+# list 2""")
+        self.assertEqual(len(root.children), 1)  # one list
+        self.assertIsInstance(root.children[0], WikiNode)
+        self.assertEqual(root.children[0].kind, NodeKind.LIST)
+
 
 # XXX implement <nowiki/> marking for links, templates
 #  - https://en.wikipedia.org/wiki/Help:Wikitext#Nowiki


### PR DESCRIPTION
but keep white spaces

fix tatuylonen/wiktextract#912