### PR TITLE
Add new `parser_function_aliases` argument to `Wtp`

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -282,7 +282,7 @@ class Wtp:
         "html_permitted_parents",
         "paired_html_tags",
         "inside_html_tags_re",
-        "invoke_aliases",
+        "parser_function_aliases",
     )
 
     def __init__(
@@ -292,8 +292,7 @@ class Wtp:
         template_override_funcs: dict[str, Callable[[Sequence[str]], str]] = {},
         project: str = "wiktionary",
         extension_tags: Optional[dict[str, HTMLTagData]] = None,
-        invoke_aliases: Optional[set[str]] = None,
-        file_aliases: Optional[set[str]] = None,
+        parser_function_aliases: dict[str, str] = {},
         quiet: bool = False,
     ):
         if isinstance(db_path, str):
@@ -351,9 +350,7 @@ class Wtp:
             self
         )
         self.inside_html_tags_re: re.Pattern = set_inside_html_tags_re(self)
-        self.invoke_aliases = {"#invoke"}
-        if invoke_aliases is not None:
-            self.invoke_aliases |= invoke_aliases
+        self.parser_function_aliases = parser_function_aliases
         if not quiet:
             logger.setLevel(logging.DEBUG)
 
@@ -1277,7 +1274,9 @@ class Wtp:
                 def expander(arg: str) -> str:
                     return expand_recurse(arg, parent, True)
 
-                if fn_name in self.invoke_aliases:
+                if fn_name in self.parser_function_aliases:
+                    fn_name = self.parser_function_aliases[fn_name]
+                if fn_name == "#invoke":
                     if not expand_invoke:
                         return "{{#invoke:" + "|".join(args) + "}}"
                     ret = invoke_fn(args, expander, parent)

--- a/tests/test_wikiprocess.py
+++ b/tests/test_wikiprocess.py
@@ -4236,7 +4236,7 @@ return export
     def test_invoke_aliases(self):
         # Some wikipedias (fr.wikipedia.org) have aliases for #invoke
         self.ctx.start_page("test")
-        self.ctx.invoke_aliases = self.ctx.invoke_aliases | {"#infooque"}
+        self.ctx.parser_function_aliases = {"#invoque": "#invoke"}
         self.ctx.add_page(
             "Module:test",
             828,
@@ -4250,11 +4250,8 @@ return export
             return export
             """,
         )
-        text = self.ctx.expand("{{#infooque|test|test}}")
-        self.assertEqual(
-            text,
-            "foo",
-        )
+        text = self.ctx.expand("{{#invoque|test|test}}")
+        self.assertEqual(text, "foo")
 
     def test_expand_template_loop_in_lua(self):
         # tatuylonen/wiktextract#894


### PR DESCRIPTION
pt edition has some parser function aliases, like `#se` for `#if`: https://pt.wikipedia.org/wiki/Ajuda:Funções_sintáticas

also remove unused arg `file_aliases`