### PR TITLE
Save default templates

### DIFF
--- a/src/wikitextprocessor/dumpparser.py
+++ b/src/wikitextprocessor/dumpparser.py
@@ -141,6 +141,7 @@ def add_default_templates(wtp: "Wtp") -> None:
         title = f"{ns_local_name}:{title}"
         if not wtp.page_exists(title, ns_id):
             wtp.add_page(title, ns_id, body)
+    wtp.db_conn.commit()
 
 
 def analyze_and_overwrite_pages(


### PR DESCRIPTION
old code doesn't save template "!" if analyze template is not enabled and it breaks pt edition's table templates. 