### PR TITLE
Expand template changes for Italian Wiktionary

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -1482,10 +1482,20 @@ class Wtp:
                         template_page = self.get_page_resolve_redirect(
                             name, ns_id
                         )
-                        if template_page is not None:
+                        if template_page is None and ":" in name:
+                            # not in template namespace
+                            template_page = self.get_page_resolve_redirect(
+                                name, None
+                            )
+                            if template_page is not None:
+                                template_page.body = self._template_to_body(
+                                    name, template_page.body
+                                )
+                        if (
+                            template_page is not None
+                            and template_page.body is not None
+                        ):
                             body = template_page.body
-                            if TYPE_CHECKING:
-                                assert body is not None
                             # XXX optimize by pre-encoding bodies during
                             # preprocessing
                             # (Each template is typically used many times)

--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -1516,7 +1516,16 @@ class Wtp:
                             #  on next iteration anyway (assuming parent
                             # unchanged). Otherwise expand the body
                             t = expand_recurse(
-                                encoded_body, new_parent, expand_all
+                                encoded_body,
+                                new_parent,
+                                expand_all
+                                or (
+                                    template_page.need_pre_expand
+                                    and not (
+                                        self.lang_code == "en"
+                                        and self.project == "wiktionary"
+                                    )
+                                ),
                             )
                         else:
                             # template doesn't exist

--- a/tests/test_wikiprocess.py
+++ b/tests/test_wikiprocess.py
@@ -8,7 +8,7 @@ import unittest
 from typing import Optional
 from unittest.mock import patch
 
-from wikitextprocessor import Page, Wtp
+from wikitextprocessor import NodeKind, Page, Wtp
 from wikitextprocessor.common import MAGIC_NOWIKI_CHAR
 
 
@@ -4293,6 +4293,23 @@ return export""",
         )
         self.ctx.start_page("cane")
         self.assertEqual(self.ctx.expand("{{Wiktionary:test}}"), "text")
+
+    def test_expand_templates_in_pre_expand_template(self):
+        self.ctx.lang_code = "it"
+        self.ctx.add_page(
+            "Template:-sost-", 10, "{{Sezione voce}}", need_pre_expand=True
+        )
+        self.ctx.add_page("Template:Sezione voce", 10, "===Sostantivo===")
+        self.ctx.start_page("cane")
+        root = self.ctx.parse(
+            """== {{-it-}} ==
+{{-sost-|it}}""",
+            pre_expand=True,
+        )
+        level2_node = root.children[0]
+        self.assertEqual(level2_node.kind, NodeKind.LEVEL2)
+        level3_node = level2_node.children[1]
+        self.assertEqual(level3_node.kind, NodeKind.LEVEL3)
 
 
 # XXX Test template_fn

--- a/tests/test_wikiprocess.py
+++ b/tests/test_wikiprocess.py
@@ -4285,6 +4285,15 @@ return export""",
         self.ctx.start_page("doodgeboren")
         self.assertEqual(self.ctx.expand("{{str len|a}}"), "a")
 
+    def test_expand_template_not_in_template_namespace(self):
+        # https://it.wiktionary.org/wiki/Template:Intestazione_voce
+        # https://it.wiktionary.org/wiki/Wikizionario:switch_lang
+        self.ctx.add_page(
+            "Wiktionary:test", 4, "text<noinclude>doc</noinclude>"
+        )
+        self.ctx.start_page("cane")
+        self.assertEqual(self.ctx.expand("{{Wiktionary:test}}"), "text")
+
 
 # XXX Test template_fn
 


### PR DESCRIPTION
Minor changes for it edition's section title templates, shouldn't affect en code.