### PR TITLE
Heading tokens `==` should be parsed from outside in.

### DIFF
--- a/src/wikitextprocessor/parser.py
+++ b/src/wikitextprocessor/parser.py
@@ -2213,10 +2213,22 @@ def token_iter(ctx: "Wtp", text: str) -> Iterator[tuple[bool, str]]:
                 # the heading itself. Fixes issue #352.
                 start, mid, _, end = hm.groups()
                 if len(start) < len(end):
-                    mid += end[len(start):]
+                    ctx.debug(
+                        f"Heading `{start}`, `{mid}`, `{end}` "
+                        f"has a start token shorter than end token: "
+                        f"shorten end and append ='s to title",
+                        sortid="parser20241218-2219",
+                    )
+                    mid += end[len(start) :]
                 elif len(start) > len(end):
-                    mid = start[len(end):] + mid
-                    start = start[:len(end)]
+                    ctx.debug(
+                        f"Heading `{start}`, `{mid}`, `{end}` "
+                        f"has an end token shorter than start token: "
+                        f"shorten start and prepend ='s to title",
+                        sortid="parser20241218-2219",
+                    )
+                    mid = start[len(end) :] + mid
+                    start = start[: len(end)]
                 yield True, "<" + start
                 # Tokenize header contents
                 for x in token_iter(ctx, mid):

--- a/src/wikitextprocessor/parser.py
+++ b/src/wikitextprocessor/parser.py
@@ -2207,11 +2207,24 @@ def token_iter(ctx: "Wtp", text: str) -> Iterator[tuple[bool, str]]:
         if hm:
             token = hm.group(0)
             if token.startswith("="):
-                yield True, "<" + hm.group(1)
+                # Wikimedia parses heading tokens from inside out:
+                # == Foo = is parsed as  =, "= Foo ", =, with leftover
+                # `=` characters in-between the bookends ending up in the
+                # the heading itself. Fixes issue #352.
+                start, mid, _, end = hm.groups()
+                if len(start) < len(end):
+                    mid += end[len(start):]
+                elif len(start) > len(end):
+                    mid = start[len(end):] + mid
+                    start = start[:len(end)]
+                yield True, "<" + start
                 # Tokenize header contents
-                for x in token_iter(ctx, hm.group(2)):
+                for x in token_iter(ctx, mid):
                     yield x
-                yield True, ">" + hm.group(4)
+                # The two heading tokens returned here should be identical,
+                # so we use `start` for both, which has been modified if
+                # the length is longer than the end token was.
+                yield True, ">" + start
             continue
         # Partition on '', so that we can detect bold/italics
         parts = re.split(parts_re, line)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3077,6 +3077,85 @@ text
         self.assertIsInstance(t_node, TemplateNode)
         self.assertEqual(t_node.template_name, "")
 
+    def test_broken_heading_control_1(self):
+        self.ctx.start_page("Foo")
+        root = self.ctx.parse("= Foo =")
+        heading = root.children[0]
+        self.assertIsInstance(heading, LevelNode)
+        self.assertEqual(heading.kind, NodeKind.LEVEL1)
+        self.assertEqual(heading.largs, [["Foo"]])
+
+    def test_broken_heading_control_2(self):
+        self.ctx.start_page("Foo")
+        root = self.ctx.parse("==Foo==")
+        heading = root.children[0]
+        self.assertIsInstance(heading, LevelNode)
+        self.assertEqual(heading.kind, NodeKind.LEVEL2)
+        self.assertEqual(heading.largs, [["Foo"]])
+
+    def test_broken_heading_1(self):
+        self.ctx.start_page("Foo")
+        root = self.ctx.parse("=Foo==")
+        heading = root.children[0]
+        self.assertIsInstance(heading, LevelNode)
+        self.assertEqual(heading.kind, NodeKind.LEVEL1)
+        self.assertEqual(heading.largs, [["Foo="]])
+
+    def test_broken_heading_2(self):
+        self.ctx.start_page("Foo")
+        root = self.ctx.parse("=Foo===")
+        heading = root.children[0]
+        self.assertIsInstance(heading, LevelNode)
+        self.assertEqual(heading.kind, NodeKind.LEVEL1)
+        self.assertEqual(heading.largs, [["Foo=="]])
+
+    def test_broken_heading_3(self):
+        self.ctx.start_page("Foo")
+        root = self.ctx.parse("==Foo===")
+        heading = root.children[0]
+        self.assertIsInstance(heading, LevelNode)
+        self.assertEqual(heading.kind, NodeKind.LEVEL2)
+        self.assertEqual(heading.largs, [["Foo="]])
+
+    def test_broken_heading_4(self):
+        self.ctx.start_page("Foo")
+        root = self.ctx.parse("==Foo=")
+        heading = root.children[0]
+        self.assertIsInstance(heading, LevelNode)
+        self.assertEqual(heading.kind, NodeKind.LEVEL1)
+        self.assertEqual(heading.largs, [["=Foo"]])
+
+    def test_broken_heading_5(self):
+        self.ctx.start_page("Foo")
+        root = self.ctx.parse("===Foo=")
+        heading = root.children[0]
+        self.assertIsInstance(heading, LevelNode)
+        self.assertEqual(heading.kind, NodeKind.LEVEL1)
+        self.assertEqual(heading.largs, [["==Foo"]])
+
+    def test_broken_heading_6(self):
+        self.ctx.start_page("Foo")
+        root = self.ctx.parse("===Foo==")
+        heading = root.children[0]
+        self.assertIsInstance(heading, LevelNode)
+        self.assertEqual(heading.kind, NodeKind.LEVEL2)
+        self.assertEqual(heading.largs, [["=Foo"]])
+
+    def test_broken_heading_7(self):
+        self.ctx.start_page("Foo")
+        root = self.ctx.parse("=Foo")
+        self.assertEqual(root.children[0], "=Foo")
+
+    def test_broken_heading_8(self):
+        self.ctx.start_page("Foo")
+        root = self.ctx.parse("==Foo")
+        self.assertEqual(root.children[0], "==Foo")
+
+    def test_broken_heading_9(self):
+        self.ctx.start_page("Foo")
+        root = self.ctx.parse("Foo==")
+        self.assertEqual(root.children[0], "Foo==")
+
 
 # XXX implement <nowiki/> marking for links, templates
 #  - https://en.wikipedia.org/wiki/Help:Wikitext#Nowiki

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3093,6 +3093,14 @@ text
         self.assertEqual(heading.kind, NodeKind.LEVEL2)
         self.assertEqual(heading.largs, [["Foo"]])
 
+    def test_broken_heading_control_3(self):
+        self.ctx.start_page("Foo")
+        root = self.ctx.parse("==Foo=Bar==")
+        heading = root.children[0]
+        self.assertIsInstance(heading, LevelNode)
+        self.assertEqual(heading.kind, NodeKind.LEVEL2)
+        self.assertEqual(heading.largs, [["Foo=Bar"]])
+
     def test_broken_heading_1(self):
         self.ctx.start_page("Foo")
         root = self.ctx.parse("=Foo==")


### PR DESCRIPTION
Wikimedia parses heading tokens from inside out:
== Foo = is parsed as  =, "= Foo ", =, with leftover `=` characters in-between the bookends ending up in the the heading itself. Fixes issue #352.

Fixed by in the portion of the code where we tokenize headings. Happily, this is already done with a regex matching a whole line, so modifying the contents of the match is easy.

I will now fix and make tests. Fails one test because the output is different from expected (mismatched `=` now go inside the heading instead of being children of the level).