### PR TITLE
Fix Lua error in reconstruction pages

### DIFF
--- a/src/wikitextprocessor/lua/mw_uri.lua
+++ b/src/wikitextprocessor/lua/mw_uri.lua
@@ -228,7 +228,11 @@ local mw_uri = {
 
 function mw_uri.anchorEncode(s)
     -- XXX how exactly should this work?
-    s = s:gsub(" ", "_"):gsub("&#x2A;", "*")
+    s = s:gsub(" ", "_"):gsub("&#x(%x+);", function(hex)
+        return string.char(tonumber(hex, 16))
+    end):gsub("&#(%d+);", function(num)
+        return string.char(tonumber(num))
+    end)
     return s
 end
 

--- a/tests/test_lua.py
+++ b/tests/test_lua.py
@@ -584,3 +584,17 @@ end
 return export""",
         )
         self.assertEqual(self.wtp.expand("{{#invoke:math|sum}}"), "1")
+
+    def test_mw_uri_anchorEncode(self):
+        # GH PR #276
+        self.wtp.start_page("Reconstruction:Proto-Turkic/us-")
+        self.wtp.add_page(
+            "Module:test",
+            828,
+            """local export = {}
+function export.test(frame)
+  return mw.uri.anchorEncode("&#42;") .. mw.uri.anchorEncode("&#x2A;")
+end
+return export""",
+        )
+        self.assertEqual(self.wtp.expand("{{#invoke:test|test}}"), "**")


### PR DESCRIPTION
similar to #276, but this time "makeDisplayText()" converts "*" to "&# 42;"