### PR TITLE
Do not split pagenames with slashes in `Main:`

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -67,6 +67,7 @@ NamespaceDataEntry = TypedDict(
         "issubject": bool,
         "istalk": bool,
         "name": str,
+        "subpages": bool,
     },
     total=True,  # fields are obligatory
 )
@@ -111,15 +112,6 @@ class CollatedErrorReturnData(TypedDict):
 CookieData = tuple[str, Sequence[str], bool]
 
 CookieChar = str
-
-EMPTY_NAMESPACEDATA: NamespaceDataEntry = {
-    "id": -1,
-    "name": "NAMESPACE_DATA_ERROR",
-    "aliases": [],
-    "content": False,
-    "istalk": False,
-    "issubject": False,
-}
 
 
 @dataclass

--- a/src/wikitextprocessor/data/de/namespaces.json
+++ b/src/wikitextprocessor/data/de/namespaces.json
@@ -2,6 +2,7 @@
   "Media": {
     "id": -2,
     "name": "Medium",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -10,6 +11,7 @@
   "Special": {
     "id": -1,
     "name": "Spezial",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -18,6 +20,7 @@
   "Main": {
     "id": 0,
     "name": "Main",
+    "subpages": false,
     "content": true,
     "aliases": [],
     "issubject": true,
@@ -26,6 +29,7 @@
   "Talk": {
     "id": 1,
     "name": "Diskussion",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -34,6 +38,7 @@
   "User": {
     "id": 2,
     "name": "Benutzer",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Benutzerin"
@@ -44,6 +49,7 @@
   "User talk": {
     "id": 3,
     "name": "Benutzer Diskussion",
+    "subpages": true,
     "content": false,
     "aliases": [
       "BD",
@@ -55,6 +61,7 @@
   "Project": {
     "id": 4,
     "name": "Wiktionary",
+    "subpages": true,
     "content": false,
     "aliases": [
       "WT"
@@ -65,6 +72,7 @@
   "Project talk": {
     "id": 5,
     "name": "Wiktionary Diskussion",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Wiktionary talk"
@@ -75,6 +83,7 @@
   "File": {
     "id": 6,
     "name": "Datei",
+    "subpages": false,
     "content": false,
     "aliases": [
       "Bild",
@@ -86,6 +95,7 @@
   "File talk": {
     "id": 7,
     "name": "Datei Diskussion",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Bild Diskussion",
@@ -97,6 +107,7 @@
   "MediaWiki": {
     "id": 8,
     "name": "MediaWiki",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -105,6 +116,7 @@
   "MediaWiki talk": {
     "id": 9,
     "name": "MediaWiki Diskussion",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -113,6 +125,7 @@
   "Template": {
     "id": 10,
     "name": "Vorlage",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -121,6 +134,7 @@
   "Template talk": {
     "id": 11,
     "name": "Vorlage Diskussion",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -129,6 +143,7 @@
   "Help": {
     "id": 12,
     "name": "Hilfe",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -137,6 +152,7 @@
   "Help talk": {
     "id": 13,
     "name": "Hilfe Diskussion",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -145,6 +161,7 @@
   "Category": {
     "id": 14,
     "name": "Kategorie",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -153,6 +170,7 @@
   "Category talk": {
     "id": 15,
     "name": "Kategorie Diskussion",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -161,6 +179,7 @@
   "Verzeichnis": {
     "id": 102,
     "name": "Verzeichnis",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -169,6 +188,7 @@
   "Verzeichnis Diskussion": {
     "id": 103,
     "name": "Verzeichnis Diskussion",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -177,6 +197,7 @@
   "Thesaurus": {
     "id": 104,
     "name": "Thesaurus",
+    "subpages": true,
     "content": false,
     "aliases": [
       "WikiSaurus"
@@ -187,6 +208,7 @@
   "Thesaurus talk": {
     "id": 105,
     "name": "Thesaurus Diskussion",
+    "subpages": true,
     "content": false,
     "aliases": [
       "WikiSaurus Diskussion"
@@ -197,6 +219,7 @@
   "Rhymes": {
     "id": 106,
     "name": "Reim",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -205,6 +228,7 @@
   "Rhymes talk": {
     "id": 107,
     "name": "Reim Diskussion",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -213,6 +237,7 @@
   "Flexion": {
     "id": 108,
     "name": "Flexion",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -221,6 +246,7 @@
   "Flexion Diskussion": {
     "id": 109,
     "name": "Flexion Diskussion",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -229,6 +255,7 @@
   "Reconstruction": {
     "id": 110,
     "name": "Rekonstruktion",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -237,6 +264,7 @@
   "Reconstruction talk": {
     "id": 111,
     "name": "Rekonstruktion Diskussion",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -245,6 +273,7 @@
   "TimedText": {
     "id": 710,
     "name": "TimedText",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -253,6 +282,7 @@
   "TimedText talk": {
     "id": 711,
     "name": "TimedText talk",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -261,6 +291,7 @@
   "Module": {
     "id": 828,
     "name": "Modul",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -269,6 +300,7 @@
   "Module talk": {
     "id": 829,
     "name": "Modul Diskussion",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,

--- a/src/wikitextprocessor/data/el/namespaces.json
+++ b/src/wikitextprocessor/data/el/namespaces.json
@@ -2,6 +2,7 @@
   "Media": {
     "id": -2,
     "name": "Μέσο",
+    "subpages": false,
     "content": false,
     "aliases": [
       "Μέσον"
@@ -12,6 +13,7 @@
   "Special": {
     "id": -1,
     "name": "Ειδικό",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -20,6 +22,7 @@
   "Main": {
     "id": 0,
     "name": "Main",
+    "subpages": false,
     "content": true,
     "aliases": [],
     "issubject": true,
@@ -28,6 +31,7 @@
   "Talk": {
     "id": 1,
     "name": "Συζήτηση",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -36,6 +40,7 @@
   "User": {
     "id": 2,
     "name": "Χρήστης",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -44,6 +49,7 @@
   "User talk": {
     "id": 3,
     "name": "Συζήτηση χρήστη",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -52,6 +58,7 @@
   "Project": {
     "id": 4,
     "name": "Βικιλεξικό",
+    "subpages": true,
     "content": false,
     "aliases": [
       "WT",
@@ -63,6 +70,7 @@
   "Project talk": {
     "id": 5,
     "name": "Συζήτηση βικιλεξικού",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Wiktionary talk",
@@ -74,6 +82,7 @@
   "File": {
     "id": 6,
     "name": "Αρχείο",
+    "subpages": false,
     "content": false,
     "aliases": [
       "Image",
@@ -85,6 +94,7 @@
   "File talk": {
     "id": 7,
     "name": "Συζήτηση αρχείου",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Image talk",
@@ -96,6 +106,7 @@
   "MediaWiki": {
     "id": 8,
     "name": "MediaWiki",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -104,6 +115,7 @@
   "MediaWiki talk": {
     "id": 9,
     "name": "Συζήτηση MediaWiki",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -112,6 +124,7 @@
   "Template": {
     "id": 10,
     "name": "Πρότυπο",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -120,6 +133,7 @@
   "Template talk": {
     "id": 11,
     "name": "Συζήτηση προτύπου",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -128,6 +142,7 @@
   "Help": {
     "id": 12,
     "name": "Βοήθεια",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -136,6 +151,7 @@
   "Help talk": {
     "id": 13,
     "name": "Συζήτηση βοήθειας",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -144,6 +160,7 @@
   "Category": {
     "id": 14,
     "name": "Κατηγορία",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -152,6 +169,7 @@
   "Category talk": {
     "id": 15,
     "name": "Συζήτηση κατηγορίας",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -160,6 +178,7 @@
   "Appendix": {
     "id": 100,
     "name": "Παράρτημα",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -168,6 +187,7 @@
   "Appendix talk": {
     "id": 101,
     "name": "Συζήτηση παραρτήματος",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -176,6 +196,7 @@
   "TimedText": {
     "id": 710,
     "name": "TimedText",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -184,6 +205,7 @@
   "TimedText talk": {
     "id": 711,
     "name": "TimedText talk",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -192,6 +214,7 @@
   "Module": {
     "id": 828,
     "name": "Module",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -200,6 +223,7 @@
   "Module talk": {
     "id": 829,
     "name": "Module talk",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,

--- a/src/wikitextprocessor/data/en/namespaces.json
+++ b/src/wikitextprocessor/data/en/namespaces.json
@@ -2,6 +2,7 @@
   "Media": {
     "id": -2,
     "name": "Media",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -10,6 +11,7 @@
   "Special": {
     "id": -1,
     "name": "Special",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -18,6 +20,7 @@
   "Main": {
     "id": 0,
     "name": "Main",
+    "subpages": false,
     "content": true,
     "aliases": [],
     "issubject": true,
@@ -26,6 +29,7 @@
   "Talk": {
     "id": 1,
     "name": "Talk",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -34,6 +38,7 @@
   "User": {
     "id": 2,
     "name": "User",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -42,6 +47,7 @@
   "User talk": {
     "id": 3,
     "name": "User talk",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -50,6 +56,7 @@
   "Project": {
     "id": 4,
     "name": "Wiktionary",
+    "subpages": true,
     "content": false,
     "aliases": [
       "WT"
@@ -60,6 +67,7 @@
   "Project talk": {
     "id": 5,
     "name": "Wiktionary talk",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -68,6 +76,7 @@
   "File": {
     "id": 6,
     "name": "File",
+    "subpages": false,
     "content": false,
     "aliases": [
       "Image"
@@ -78,6 +87,7 @@
   "File talk": {
     "id": 7,
     "name": "File talk",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Image talk"
@@ -88,6 +98,7 @@
   "MediaWiki": {
     "id": 8,
     "name": "MediaWiki",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -96,6 +107,7 @@
   "MediaWiki talk": {
     "id": 9,
     "name": "MediaWiki talk",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -104,6 +116,7 @@
   "Template": {
     "id": 10,
     "name": "Template",
+    "subpages": true,
     "content": false,
     "aliases": [
       "T"
@@ -114,6 +127,7 @@
   "Template talk": {
     "id": 11,
     "name": "Template talk",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -122,6 +136,7 @@
   "Help": {
     "id": 12,
     "name": "Help",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -130,6 +145,7 @@
   "Help talk": {
     "id": 13,
     "name": "Help talk",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -138,6 +154,7 @@
   "Category": {
     "id": 14,
     "name": "Category",
+    "subpages": false,
     "content": false,
     "aliases": [
       "CAT"
@@ -148,6 +165,7 @@
   "Category talk": {
     "id": 15,
     "name": "Category talk",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -156,6 +174,7 @@
   "Thread": {
     "id": 90,
     "name": "Thread",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -164,6 +183,7 @@
   "Thread talk": {
     "id": 91,
     "name": "Thread talk",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -172,6 +192,7 @@
   "Summary": {
     "id": 92,
     "name": "Summary",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -180,6 +201,7 @@
   "Summary talk": {
     "id": 93,
     "name": "Summary talk",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -188,6 +210,7 @@
   "Appendix": {
     "id": 100,
     "name": "Appendix",
+    "subpages": true,
     "content": false,
     "aliases": [
       "AP"
@@ -198,6 +221,7 @@
   "Appendix talk": {
     "id": 101,
     "name": "Appendix talk",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -206,6 +230,7 @@
   "Rhymes": {
     "id": 106,
     "name": "Rhymes",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -214,6 +239,7 @@
   "Rhymes talk": {
     "id": 107,
     "name": "Rhymes talk",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -222,6 +248,7 @@
   "Transwiki": {
     "id": 108,
     "name": "Transwiki",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -230,6 +257,7 @@
   "Transwiki talk": {
     "id": 109,
     "name": "Transwiki talk",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -238,6 +266,7 @@
   "Thesaurus": {
     "id": 110,
     "name": "Thesaurus",
+    "subpages": true,
     "content": false,
     "aliases": [
       "WS",
@@ -249,6 +278,7 @@
   "Thesaurus talk": {
     "id": 111,
     "name": "Thesaurus talk",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Wikisaurus talk"
@@ -259,6 +289,7 @@
   "Citations": {
     "id": 114,
     "name": "Citations",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -267,6 +298,7 @@
   "Citations talk": {
     "id": 115,
     "name": "Citations talk",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -275,6 +307,7 @@
   "Sign gloss": {
     "id": 116,
     "name": "Sign gloss",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -283,6 +316,7 @@
   "Sign gloss talk": {
     "id": 117,
     "name": "Sign gloss talk",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -291,6 +325,7 @@
   "Reconstruction": {
     "id": 118,
     "name": "Reconstruction",
+    "subpages": true,
     "content": false,
     "aliases": [
       "RC"
@@ -301,6 +336,7 @@
   "Reconstruction talk": {
     "id": 119,
     "name": "Reconstruction talk",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -309,6 +345,7 @@
   "TimedText": {
     "id": 710,
     "name": "TimedText",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -317,6 +354,7 @@
   "TimedText talk": {
     "id": 711,
     "name": "TimedText talk",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -325,6 +363,7 @@
   "Module": {
     "id": 828,
     "name": "Module",
+    "subpages": true,
     "content": false,
     "aliases": [
       "MOD"
@@ -335,6 +374,7 @@
   "Module talk": {
     "id": 829,
     "name": "Module talk",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,

--- a/src/wikitextprocessor/data/es/namespaces.json
+++ b/src/wikitextprocessor/data/es/namespaces.json
@@ -2,6 +2,7 @@
   "Media": {
     "id": -2,
     "name": "Medio",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -10,6 +11,7 @@
   "Special": {
     "id": -1,
     "name": "Especial",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -18,6 +20,7 @@
   "Main": {
     "id": 0,
     "name": "Main",
+    "subpages": false,
     "content": true,
     "aliases": [],
     "issubject": true,
@@ -26,6 +29,7 @@
   "Talk": {
     "id": 1,
     "name": "Discusión",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -34,54 +38,77 @@
   "User": {
     "id": 2,
     "name": "Usuario",
+    "subpages": true,
     "content": false,
-    "aliases": ["Usuaria"],
+    "aliases": [
+      "Usuaria"
+    ],
     "issubject": true,
     "istalk": false
   },
   "User talk": {
     "id": 3,
     "name": "Usuario discusión",
+    "subpages": true,
     "content": false,
-    "aliases": ["Usuaria discusión"],
+    "aliases": [
+      "Usuaria discusión"
+    ],
     "issubject": false,
     "istalk": true
   },
   "Project": {
     "id": 4,
     "name": "Wikcionario",
+    "subpages": true,
     "content": false,
-    "aliases": ["WN", "WT", "Wiktionary"],
+    "aliases": [
+      "WN",
+      "WT",
+      "Wiktionary"
+    ],
     "issubject": true,
     "istalk": false
   },
   "Project talk": {
     "id": 5,
     "name": "Wikcionario discusión",
+    "subpages": true,
     "content": false,
-    "aliases": ["Wiktionary talk"],
+    "aliases": [
+      "Wiktionary talk"
+    ],
     "issubject": false,
     "istalk": true
   },
   "File": {
     "id": 6,
     "name": "Archivo",
+    "subpages": false,
     "content": false,
-    "aliases": ["Image", "Imagen"],
+    "aliases": [
+      "Image",
+      "Imagen"
+    ],
     "issubject": true,
     "istalk": false
   },
   "File talk": {
     "id": 7,
     "name": "Archivo discusión",
+    "subpages": true,
     "content": false,
-    "aliases": ["Image talk", "Imagen discusión"],
+    "aliases": [
+      "Image talk",
+      "Imagen discusión"
+    ],
     "issubject": false,
     "istalk": true
   },
   "MediaWiki": {
     "id": 8,
     "name": "MediaWiki",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -90,6 +117,7 @@
   "MediaWiki talk": {
     "id": 9,
     "name": "MediaWiki discusión",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -98,6 +126,7 @@
   "Template": {
     "id": 10,
     "name": "Plantilla",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -106,6 +135,7 @@
   "Template talk": {
     "id": 11,
     "name": "Plantilla discusión",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -114,6 +144,7 @@
   "Help": {
     "id": 12,
     "name": "Ayuda",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -122,6 +153,7 @@
   "Help talk": {
     "id": 13,
     "name": "Ayuda discusión",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -130,6 +162,7 @@
   "Category": {
     "id": 14,
     "name": "Categoría",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -138,6 +171,7 @@
   "Category talk": {
     "id": 15,
     "name": "Categoría discusión",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -146,14 +180,16 @@
   "Appendix": {
     "id": 100,
     "name": "Apéndice",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
     "istalk": false
   },
-  "Appendix Discusión": {
+  "Appendix talk": {
     "id": 101,
     "name": "Apéndice Discusión",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -162,6 +198,7 @@
   "TimedText": {
     "id": 710,
     "name": "TimedText",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -170,6 +207,7 @@
   "TimedText talk": {
     "id": 711,
     "name": "TimedText talk",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -178,6 +216,7 @@
   "Module": {
     "id": 828,
     "name": "Módulo",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -186,38 +225,7 @@
   "Module talk": {
     "id": 829,
     "name": "Módulo discusión",
-    "content": false,
-    "aliases": [],
-    "issubject": false,
-    "istalk": true
-  },
-  "Gadget": {
-    "id": 2300,
-    "name": "Accesorio",
-    "content": false,
-    "aliases": [],
-    "issubject": true,
-    "istalk": false
-  },
-  "Gadget talk": {
-    "id": 2301,
-    "name": "Accesorio discusión",
-    "content": false,
-    "aliases": [],
-    "issubject": false,
-    "istalk": true
-  },
-  "Gadget definition": {
-    "id": 2302,
-    "name": "Accesorio definición",
-    "content": false,
-    "aliases": [],
-    "issubject": true,
-    "istalk": false
-  },
-  "Gadget definition talk": {
-    "id": 2303,
-    "name": "Accesorio definición discusión",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,

--- a/src/wikitextprocessor/data/fr/namespaces.json
+++ b/src/wikitextprocessor/data/fr/namespaces.json
@@ -2,6 +2,7 @@
   "Media": {
     "id": -2,
     "name": "Média",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -10,6 +11,7 @@
   "Special": {
     "id": -1,
     "name": "Spécial",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -18,6 +20,7 @@
   "Main": {
     "id": 0,
     "name": "Main",
+    "subpages": false,
     "content": true,
     "aliases": [],
     "issubject": true,
@@ -26,6 +29,7 @@
   "Talk": {
     "id": 1,
     "name": "Discussion",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Discuter"
@@ -36,6 +40,7 @@
   "User": {
     "id": 2,
     "name": "Utilisateur",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Utilisatrice"
@@ -46,6 +51,7 @@
   "User talk": {
     "id": 3,
     "name": "Discussion utilisateur",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Discussion Utilisateur",
@@ -57,6 +63,7 @@
   "Project": {
     "id": 4,
     "name": "Wiktionnaire",
+    "subpages": true,
     "content": false,
     "aliases": [
       "WT",
@@ -68,6 +75,7 @@
   "Project talk": {
     "id": 5,
     "name": "Discussion Wiktionnaire",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Wiktionary talk"
@@ -78,6 +86,7 @@
   "File": {
     "id": 6,
     "name": "Fichier",
+    "subpages": false,
     "content": false,
     "aliases": [
       "Image"
@@ -88,6 +97,7 @@
   "File talk": {
     "id": 7,
     "name": "Discussion fichier",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Discussion Fichier",
@@ -100,6 +110,7 @@
   "MediaWiki": {
     "id": 8,
     "name": "MediaWiki",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -108,6 +119,7 @@
   "MediaWiki talk": {
     "id": 9,
     "name": "Discussion MediaWiki",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -116,6 +128,7 @@
   "Template": {
     "id": 10,
     "name": "Modèle",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -124,6 +137,7 @@
   "Template talk": {
     "id": 11,
     "name": "Discussion modèle",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Discussion Modèle"
@@ -134,6 +148,7 @@
   "Help": {
     "id": 12,
     "name": "Aide",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -142,6 +157,7 @@
   "Help talk": {
     "id": 13,
     "name": "Discussion aide",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Discussion Aide"
@@ -152,6 +168,7 @@
   "Category": {
     "id": 14,
     "name": "Catégorie",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -160,6 +177,7 @@
   "Category talk": {
     "id": 15,
     "name": "Discussion catégorie",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Discussion Catégorie"
@@ -170,6 +188,7 @@
   "Appendix": {
     "id": 100,
     "name": "Annexe",
+    "subpages": true,
     "content": true,
     "aliases": [],
     "issubject": true,
@@ -178,6 +197,7 @@
   "Appendix talk": {
     "id": 101,
     "name": "Discussion Annexe",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -186,6 +206,7 @@
   "Transwiki": {
     "id": 102,
     "name": "Transwiki",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -194,6 +215,7 @@
   "Transwiki talk": {
     "id": 103,
     "name": "Discussion Transwiki",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -202,6 +224,7 @@
   "Portail": {
     "id": 104,
     "name": "Portail",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -210,6 +233,7 @@
   "Discussion Portail": {
     "id": 105,
     "name": "Discussion Portail",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -218,6 +242,7 @@
   "Thesaurus": {
     "id": 106,
     "name": "Thésaurus",
+    "subpages": true,
     "content": true,
     "aliases": [],
     "issubject": true,
@@ -226,6 +251,7 @@
   "Thesaurus talk": {
     "id": 107,
     "name": "Discussion Thésaurus",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -234,6 +260,7 @@
   "Projet": {
     "id": 108,
     "name": "Projet",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -242,6 +269,7 @@
   "Discussion Projet": {
     "id": 109,
     "name": "Discussion Projet",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -250,6 +278,7 @@
   "Reconstruction": {
     "id": 110,
     "name": "Reconstruction",
+    "subpages": true,
     "content": true,
     "aliases": [],
     "issubject": true,
@@ -258,6 +287,7 @@
   "Reconstruction talk": {
     "id": 111,
     "name": "Discussion Reconstruction",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -266,6 +296,7 @@
   "Tutoriel": {
     "id": 112,
     "name": "Tutoriel",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -274,6 +305,7 @@
   "Discussion Tutoriel": {
     "id": 113,
     "name": "Discussion Tutoriel",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -282,6 +314,7 @@
   "Rime": {
     "id": 114,
     "name": "Rime",
+    "subpages": true,
     "content": true,
     "aliases": [],
     "issubject": true,
@@ -290,6 +323,7 @@
   "Discussion Rime": {
     "id": 115,
     "name": "Discussion Rime",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -298,6 +332,7 @@
   "Conjugaison": {
     "id": 116,
     "name": "Conjugaison",
+    "subpages": true,
     "content": true,
     "aliases": [
       "conj"
@@ -308,6 +343,7 @@
   "Discussion Conjugaison": {
     "id": 117,
     "name": "Discussion Conjugaison",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -316,6 +352,7 @@
   "Racine": {
     "id": 118,
     "name": "Racine",
+    "subpages": true,
     "content": true,
     "aliases": [],
     "issubject": true,
@@ -324,6 +361,27 @@
   "Discussion Racine": {
     "id": 119,
     "name": "Discussion Racine",
+    "subpages": true,
+    "content": false,
+    "aliases": [],
+    "issubject": false,
+    "istalk": true
+  },
+  "Convention": {
+    "id": 120,
+    "name": "Convention",
+    "subpages": false,
+    "content": false,
+    "aliases": [
+      "CVT"
+    ],
+    "issubject": true,
+    "istalk": false
+  },
+  "Discussion Convention": {
+    "id": 121,
+    "name": "Discussion Convention",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -332,6 +390,7 @@
   "TimedText": {
     "id": 710,
     "name": "TimedText",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -340,6 +399,7 @@
   "TimedText talk": {
     "id": 711,
     "name": "TimedText talk",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -348,6 +408,7 @@
   "Module": {
     "id": 828,
     "name": "Module",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -356,6 +417,7 @@
   "Module talk": {
     "id": 829,
     "name": "Discussion module",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -364,6 +426,7 @@
   "Translations": {
     "id": 1198,
     "name": "Translations",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -372,6 +435,7 @@
   "Translations talk": {
     "id": 1199,
     "name": "Translations talk",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -380,6 +444,7 @@
   "Topic": {
     "id": 2600,
     "name": "Sujet",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,

--- a/src/wikitextprocessor/data/it/namespaces.json
+++ b/src/wikitextprocessor/data/it/namespaces.json
@@ -2,6 +2,7 @@
   "Media": {
     "id": -2,
     "name": "Media",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -10,6 +11,7 @@
   "Special": {
     "id": -1,
     "name": "Speciale",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -18,6 +20,7 @@
   "Main": {
     "id": 0,
     "name": "Main",
+    "subpages": false,
     "content": true,
     "aliases": [],
     "issubject": true,
@@ -26,6 +29,7 @@
   "Talk": {
     "id": 1,
     "name": "Discussione",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -34,6 +38,7 @@
   "User": {
     "id": 2,
     "name": "Utente",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -42,6 +47,7 @@
   "User talk": {
     "id": 3,
     "name": "Discussioni utente",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -50,6 +56,7 @@
   "Project": {
     "id": 4,
     "name": "Wikizionario",
+    "subpages": true,
     "content": false,
     "aliases": [
       "WT",
@@ -62,6 +69,7 @@
   "Project talk": {
     "id": 5,
     "name": "Discussioni Wikizionario",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Wiktionary talk"
@@ -72,6 +80,7 @@
   "File": {
     "id": 6,
     "name": "File",
+    "subpages": false,
     "content": false,
     "aliases": [
       "Image",
@@ -83,6 +92,7 @@
   "File talk": {
     "id": 7,
     "name": "Discussioni file",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Discussioni immagine",
@@ -94,6 +104,7 @@
   "MediaWiki": {
     "id": 8,
     "name": "MediaWiki",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -102,6 +113,7 @@
   "MediaWiki talk": {
     "id": 9,
     "name": "Discussioni MediaWiki",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -110,6 +122,7 @@
   "Template": {
     "id": 10,
     "name": "Template",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -118,6 +131,7 @@
   "Template talk": {
     "id": 11,
     "name": "Discussioni template",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -126,6 +140,7 @@
   "Help": {
     "id": 12,
     "name": "Aiuto",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -134,6 +149,7 @@
   "Help talk": {
     "id": 13,
     "name": "Discussioni aiuto",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -142,6 +158,7 @@
   "Category": {
     "id": 14,
     "name": "Categoria",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -150,6 +167,7 @@
   "Category talk": {
     "id": 15,
     "name": "Discussioni categoria",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -158,6 +176,7 @@
   "Appendix": {
     "id": 100,
     "name": "Appendice",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -166,6 +185,7 @@
   "Appendix talk": {
     "id": 101,
     "name": "Discussioni appendice",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -174,6 +194,7 @@
   "TimedText": {
     "id": 710,
     "name": "TimedText",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -182,6 +203,7 @@
   "TimedText talk": {
     "id": 711,
     "name": "TimedText talk",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -190,6 +212,7 @@
   "Module": {
     "id": 828,
     "name": "Modulo",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -198,6 +221,7 @@
   "Module talk": {
     "id": 829,
     "name": "Discussioni modulo",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,

--- a/src/wikitextprocessor/data/ja/namespaces.json
+++ b/src/wikitextprocessor/data/ja/namespaces.json
@@ -2,6 +2,7 @@
   "Media": {
     "id": -2,
     "name": "メディア",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -10,6 +11,7 @@
   "Special": {
     "id": -1,
     "name": "特別",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -18,6 +20,7 @@
   "Main": {
     "id": 0,
     "name": "Main",
+    "subpages": false,
     "content": true,
     "aliases": [],
     "issubject": true,
@@ -26,6 +29,7 @@
   "Talk": {
     "id": 1,
     "name": "トーク",
+    "subpages": true,
     "content": false,
     "aliases": [
       "ノート"
@@ -36,6 +40,7 @@
   "User": {
     "id": 2,
     "name": "利用者",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -44,6 +49,7 @@
   "User talk": {
     "id": 3,
     "name": "利用者・トーク",
+    "subpages": true,
     "content": false,
     "aliases": [
       "利用者‐会話"
@@ -54,6 +60,7 @@
   "Project": {
     "id": 4,
     "name": "Wiktionary",
+    "subpages": true,
     "content": false,
     "aliases": [
       "WT"
@@ -64,6 +71,7 @@
   "Project talk": {
     "id": 5,
     "name": "Wiktionary・トーク",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Wiktionary talk",
@@ -75,6 +83,7 @@
   "File": {
     "id": 6,
     "name": "ファイル",
+    "subpages": false,
     "content": false,
     "aliases": [
       "Image",
@@ -86,6 +95,7 @@
   "File talk": {
     "id": 7,
     "name": "ファイル・トーク",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Image talk",
@@ -98,6 +108,7 @@
   "MediaWiki": {
     "id": 8,
     "name": "MediaWiki",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -106,6 +117,7 @@
   "MediaWiki talk": {
     "id": 9,
     "name": "MediaWiki・トーク",
+    "subpages": true,
     "content": false,
     "aliases": [
       "MediaWiki‐ノート"
@@ -116,6 +128,7 @@
   "Template": {
     "id": 10,
     "name": "テンプレート",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -124,6 +137,7 @@
   "Template talk": {
     "id": 11,
     "name": "テンプレート・トーク",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Template‐ノート"
@@ -134,6 +148,7 @@
   "Help": {
     "id": 12,
     "name": "ヘルプ",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -142,6 +157,7 @@
   "Help talk": {
     "id": 13,
     "name": "ヘルプ・トーク",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Help‐ノート"
@@ -152,6 +168,7 @@
   "Category": {
     "id": 14,
     "name": "カテゴリ",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -160,6 +177,7 @@
   "Category talk": {
     "id": 15,
     "name": "カテゴリ・トーク",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Category‐ノート"
@@ -170,6 +188,7 @@
   "Appendix": {
     "id": 100,
     "name": "付録",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -178,6 +197,7 @@
   "Appendix talk": {
     "id": 101,
     "name": "付録・トーク",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -186,6 +206,7 @@
   "TimedText": {
     "id": 710,
     "name": "TimedText",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -194,6 +215,7 @@
   "TimedText talk": {
     "id": 711,
     "name": "TimedText talk",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -202,6 +224,7 @@
   "Module": {
     "id": 828,
     "name": "モジュール",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -210,6 +233,7 @@
   "Module talk": {
     "id": 829,
     "name": "モジュール・トーク",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,

--- a/src/wikitextprocessor/data/ko/namespaces.json
+++ b/src/wikitextprocessor/data/ko/namespaces.json
@@ -2,6 +2,7 @@
   "Media": {
     "id": -2,
     "name": "미디어",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -10,6 +11,7 @@
   "Special": {
     "id": -1,
     "name": "특수",
+    "subpages": false,
     "content": false,
     "aliases": [
       "특",
@@ -21,6 +23,7 @@
   "Main": {
     "id": 0,
     "name": "Main",
+    "subpages": false,
     "content": true,
     "aliases": [],
     "issubject": true,
@@ -29,6 +32,7 @@
   "Talk": {
     "id": 1,
     "name": "토론",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -37,6 +41,7 @@
   "User": {
     "id": 2,
     "name": "사용자",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -45,6 +50,7 @@
   "User talk": {
     "id": 3,
     "name": "사용자토론",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -53,6 +59,7 @@
   "Project": {
     "id": 4,
     "name": "위키낱말사전",
+    "subpages": true,
     "content": false,
     "aliases": [
       "WT",
@@ -65,6 +72,7 @@
   "Project talk": {
     "id": 5,
     "name": "위키낱말사전토론",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Wiktionary talk"
@@ -75,6 +83,7 @@
   "File": {
     "id": 6,
     "name": "파일",
+    "subpages": false,
     "content": false,
     "aliases": [
       "Image",
@@ -86,6 +95,7 @@
   "File talk": {
     "id": 7,
     "name": "파일토론",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Image talk",
@@ -97,6 +107,7 @@
   "MediaWiki": {
     "id": 8,
     "name": "미디어위키",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -105,6 +116,7 @@
   "MediaWiki talk": {
     "id": 9,
     "name": "미디어위키토론",
+    "subpages": true,
     "content": false,
     "aliases": [
       "MediaWiki토론"
@@ -115,6 +127,7 @@
   "Template": {
     "id": 10,
     "name": "틀",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -123,6 +136,7 @@
   "Template talk": {
     "id": 11,
     "name": "틀토론",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -131,6 +145,7 @@
   "Help": {
     "id": 12,
     "name": "도움말",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -139,6 +154,7 @@
   "Help talk": {
     "id": 13,
     "name": "도움말토론",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -147,6 +163,7 @@
   "Category": {
     "id": 14,
     "name": "분류",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -155,6 +172,7 @@
   "Category talk": {
     "id": 15,
     "name": "분류토론",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -163,6 +181,7 @@
   "Appendix": {
     "id": 100,
     "name": "부록",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -171,6 +190,7 @@
   "Appendix talk": {
     "id": 101,
     "name": "부록 토론",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -179,6 +199,7 @@
   "TimedText": {
     "id": 710,
     "name": "TimedText",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -187,6 +208,7 @@
   "TimedText talk": {
     "id": 711,
     "name": "TimedText talk",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -195,6 +217,7 @@
   "Module": {
     "id": 828,
     "name": "모듈",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -203,6 +226,7 @@
   "Module talk": {
     "id": 829,
     "name": "모듈토론",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,

--- a/src/wikitextprocessor/data/ku/namespaces.json
+++ b/src/wikitextprocessor/data/ku/namespaces.json
@@ -2,6 +2,7 @@
   "Media": {
     "id": -2,
     "name": "Medya",
+    "subpages": false,
     "content": false,
     "aliases": [
       "میدیا"
@@ -12,6 +13,7 @@
   "Special": {
     "id": -1,
     "name": "Taybet",
+    "subpages": false,
     "content": false,
     "aliases": [
       "تایبەت"
@@ -22,6 +24,7 @@
   "Main": {
     "id": 0,
     "name": "Main",
+    "subpages": false,
     "content": true,
     "aliases": [],
     "issubject": true,
@@ -30,6 +33,7 @@
   "Talk": {
     "id": 1,
     "name": "Gotûbêj",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Nîqaş",
@@ -41,6 +45,7 @@
   "User": {
     "id": 2,
     "name": "Bikarhêner",
+    "subpages": true,
     "content": false,
     "aliases": [
       "بەکارھێنەر"
@@ -51,6 +56,7 @@
   "User talk": {
     "id": 3,
     "name": "Gotûbêja bikarhêner",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Bikarhêner nîqaş",
@@ -62,6 +68,7 @@
   "Project": {
     "id": 4,
     "name": "Wîkîferheng",
+    "subpages": true,
     "content": false,
     "aliases": [
       "WF",
@@ -74,6 +81,7 @@
   "Project talk": {
     "id": 5,
     "name": "Gotûbêja Wîkîferhengê",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Wiktionary talk",
@@ -86,6 +94,7 @@
   "File": {
     "id": 6,
     "name": "Wêne",
+    "subpages": false,
     "content": false,
     "aliases": [
       "Image",
@@ -97,6 +106,7 @@
   "File talk": {
     "id": 7,
     "name": "Gotûbêja wêneyî",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Image talk",
@@ -109,6 +119,7 @@
   "MediaWiki": {
     "id": 8,
     "name": "MediaWiki",
+    "subpages": true,
     "content": false,
     "aliases": [
       "میدیاویکی"
@@ -119,6 +130,7 @@
   "MediaWiki talk": {
     "id": 9,
     "name": "Gotûbêja MediaWiki",
+    "subpages": true,
     "content": false,
     "aliases": [
       "MediaWiki nîqaş",
@@ -130,6 +142,7 @@
   "Template": {
     "id": 10,
     "name": "Şablon",
+    "subpages": true,
     "content": false,
     "aliases": [
       "داڕێژە"
@@ -140,6 +153,7 @@
   "Template talk": {
     "id": 11,
     "name": "Gotûbêja şablonê",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Şablon nîqaş",
@@ -151,6 +165,7 @@
   "Help": {
     "id": 12,
     "name": "Alîkarî",
+    "subpages": true,
     "content": false,
     "aliases": [
       "یارمەتی"
@@ -161,6 +176,7 @@
   "Help talk": {
     "id": 13,
     "name": "Gotûbêja alîkariyê",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Alîkarî nîqaş",
@@ -172,6 +188,7 @@
   "Category": {
     "id": 14,
     "name": "Kategorî",
+    "subpages": false,
     "content": false,
     "aliases": [
       "پۆل"
@@ -182,6 +199,7 @@
   "Category talk": {
     "id": 15,
     "name": "Gotûbêja kategoriyê",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Kategorî nîqaş",
@@ -193,6 +211,7 @@
   "Appendix": {
     "id": 100,
     "name": "Pêvek",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -201,6 +220,7 @@
   "Appendix talk": {
     "id": 101,
     "name": "Gotûbêja pêvekê",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Pêvek nîqas"
@@ -211,6 +231,7 @@
   "Nimînok": {
     "id": 102,
     "name": "Nimînok",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -219,6 +240,7 @@
   "Gotûbêja nimînokê": {
     "id": 103,
     "name": "Gotûbêja nimînokê",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Nimînok nîqas"
@@ -229,6 +251,7 @@
   "Portal": {
     "id": 104,
     "name": "Portal",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -237,6 +260,7 @@
   "Gotûbêja portalê": {
     "id": 105,
     "name": "Gotûbêja portalê",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Portal nîqas"
@@ -247,6 +271,7 @@
   "Tewandin": {
     "id": 106,
     "name": "Tewandin",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -255,6 +280,7 @@
   "Gotûbêja tewandinê": {
     "id": 107,
     "name": "Gotûbêja tewandinê",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -263,6 +289,7 @@
   "Reconstruction": {
     "id": 108,
     "name": "Jinûvesazî",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -271,6 +298,7 @@
   "Reconstruction talk": {
     "id": 109,
     "name": "Gotûbêja jinûvesaziyê",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -279,6 +307,7 @@
   "TimedText": {
     "id": 710,
     "name": "TimedText",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -287,6 +316,7 @@
   "TimedText talk": {
     "id": 711,
     "name": "TimedText talk",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -295,6 +325,7 @@
   "Module": {
     "id": 828,
     "name": "Modul",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -303,6 +334,7 @@
   "Module talk": {
     "id": 829,
     "name": "Gotûbêja modulê",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,

--- a/src/wikitextprocessor/data/nl/namespaces.json
+++ b/src/wikitextprocessor/data/nl/namespaces.json
@@ -2,6 +2,7 @@
   "Media": {
     "id": -2,
     "name": "Media",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -10,6 +11,7 @@
   "Special": {
     "id": -1,
     "name": "Speciaal",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -18,6 +20,7 @@
   "Main": {
     "id": 0,
     "name": "Main",
+    "subpages": false,
     "content": true,
     "aliases": [],
     "issubject": true,
@@ -26,6 +29,7 @@
   "Talk": {
     "id": 1,
     "name": "Overleg",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -34,6 +38,7 @@
   "User": {
     "id": 2,
     "name": "Gebruiker",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -42,6 +47,7 @@
   "User talk": {
     "id": 3,
     "name": "Overleg gebruiker",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -50,6 +56,7 @@
   "Project": {
     "id": 4,
     "name": "WikiWoordenboek",
+    "subpages": true,
     "content": false,
     "aliases": [
       "WT",
@@ -61,6 +68,7 @@
   "Project talk": {
     "id": 5,
     "name": "Overleg WikiWoordenboek",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Wiktionary talk"
@@ -71,6 +79,7 @@
   "File": {
     "id": 6,
     "name": "Bestand",
+    "subpages": false,
     "content": false,
     "aliases": [
       "Afbeelding",
@@ -82,6 +91,7 @@
   "File talk": {
     "id": 7,
     "name": "Overleg bestand",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Image talk",
@@ -93,6 +103,7 @@
   "MediaWiki": {
     "id": 8,
     "name": "MediaWiki",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -101,6 +112,7 @@
   "MediaWiki talk": {
     "id": 9,
     "name": "Overleg MediaWiki",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -109,6 +121,7 @@
   "Template": {
     "id": 10,
     "name": "Sjabloon",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -117,6 +130,7 @@
   "Template talk": {
     "id": 11,
     "name": "Overleg sjabloon",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -125,6 +139,7 @@
   "Help": {
     "id": 12,
     "name": "Help",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -133,6 +148,7 @@
   "Help talk": {
     "id": 13,
     "name": "Overleg help",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -141,6 +157,7 @@
   "Category": {
     "id": 14,
     "name": "Categorie",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -149,6 +166,7 @@
   "Category talk": {
     "id": 15,
     "name": "Overleg categorie",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -157,6 +175,7 @@
   "TimedText": {
     "id": 710,
     "name": "TimedText",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -165,6 +184,7 @@
   "TimedText talk": {
     "id": 711,
     "name": "TimedText talk",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -173,6 +193,7 @@
   "Module": {
     "id": 828,
     "name": "Module",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -181,6 +202,7 @@
   "Module talk": {
     "id": 829,
     "name": "Overleg module",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,

--- a/src/wikitextprocessor/data/pl/namespaces.json
+++ b/src/wikitextprocessor/data/pl/namespaces.json
@@ -2,6 +2,7 @@
   "Media": {
     "id": -2,
     "name": "Media",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -10,6 +11,7 @@
   "Special": {
     "id": -1,
     "name": "Specjalna",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -18,6 +20,7 @@
   "Main": {
     "id": 0,
     "name": "Main",
+    "subpages": false,
     "content": true,
     "aliases": [],
     "issubject": true,
@@ -26,6 +29,7 @@
   "Talk": {
     "id": 1,
     "name": "Dyskusja",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -34,6 +38,7 @@
   "User": {
     "id": 2,
     "name": "Wikisłownikarz",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Wikipedysta",
@@ -46,6 +51,7 @@
   "User talk": {
     "id": 3,
     "name": "Dyskusja wikisłownikarza",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Dyskusja wikipedystki",
@@ -58,6 +64,7 @@
   "Project": {
     "id": 4,
     "name": "Wikisłownik",
+    "subpages": true,
     "content": false,
     "aliases": [
       "WS",
@@ -70,6 +77,7 @@
   "Project talk": {
     "id": 5,
     "name": "Wikidyskusja",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Wiktionary talk"
@@ -80,6 +88,7 @@
   "File": {
     "id": 6,
     "name": "Plik",
+    "subpages": false,
     "content": false,
     "aliases": [
       "Grafika",
@@ -91,6 +100,7 @@
   "File talk": {
     "id": 7,
     "name": "Dyskusja pliku",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Dyskusja grafiki",
@@ -102,6 +112,7 @@
   "MediaWiki": {
     "id": 8,
     "name": "MediaWiki",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -110,6 +121,7 @@
   "MediaWiki talk": {
     "id": 9,
     "name": "Dyskusja MediaWiki",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -118,6 +130,7 @@
   "Template": {
     "id": 10,
     "name": "Szablon",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -126,6 +139,7 @@
   "Template talk": {
     "id": 11,
     "name": "Dyskusja szablonu",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -134,6 +148,7 @@
   "Help": {
     "id": 12,
     "name": "Pomoc",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -142,6 +157,7 @@
   "Help talk": {
     "id": 13,
     "name": "Dyskusja pomocy",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -150,6 +166,7 @@
   "Category": {
     "id": 14,
     "name": "Kategoria",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -158,6 +175,7 @@
   "Category talk": {
     "id": 15,
     "name": "Dyskusja kategorii",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -166,6 +184,7 @@
   "Appendix": {
     "id": 100,
     "name": "Aneks",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -174,6 +193,7 @@
   "Appendix talk": {
     "id": 101,
     "name": "Dyskusja aneksu",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -182,6 +202,7 @@
   "Indeks": {
     "id": 102,
     "name": "Indeks",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -190,6 +211,7 @@
   "Dyskusja indeksu": {
     "id": 103,
     "name": "Dyskusja indeksu",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -198,6 +220,7 @@
   "Portal": {
     "id": 104,
     "name": "Portal",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -206,6 +229,7 @@
   "Dyskusja portalu": {
     "id": 105,
     "name": "Dyskusja portalu",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -214,6 +238,7 @@
   "TimedText": {
     "id": 710,
     "name": "TimedText",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -222,6 +247,7 @@
   "TimedText talk": {
     "id": 711,
     "name": "TimedText talk",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -230,6 +256,7 @@
   "Module": {
     "id": 828,
     "name": "Moduł",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -238,6 +265,7 @@
   "Module talk": {
     "id": 829,
     "name": "Dyskusja modułu",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,

--- a/src/wikitextprocessor/data/pt/namespaces.json
+++ b/src/wikitextprocessor/data/pt/namespaces.json
@@ -2,6 +2,7 @@
   "Media": {
     "id": -2,
     "name": "Multimédia",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -10,6 +11,7 @@
   "Special": {
     "id": -1,
     "name": "Especial",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -18,6 +20,7 @@
   "Main": {
     "id": 0,
     "name": "Main",
+    "subpages": false,
     "content": true,
     "aliases": [],
     "issubject": true,
@@ -26,6 +29,7 @@
   "Talk": {
     "id": 1,
     "name": "Discussão",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -34,6 +38,7 @@
   "User": {
     "id": 2,
     "name": "Utilizador",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Usuária",
@@ -48,6 +53,7 @@
   "User talk": {
     "id": 3,
     "name": "Utilizador Discussão",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Usuária Discussão",
@@ -62,6 +68,7 @@
   "Project": {
     "id": 4,
     "name": "Wikcionário",
+    "subpages": true,
     "content": false,
     "aliases": [
       "WT",
@@ -73,6 +80,7 @@
   "Project talk": {
     "id": 5,
     "name": "Wikcionário Discussão",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Wiktionary talk"
@@ -83,6 +91,7 @@
   "File": {
     "id": 6,
     "name": "Ficheiro",
+    "subpages": false,
     "content": false,
     "aliases": [
       "Arquivo",
@@ -95,6 +104,7 @@
   "File talk": {
     "id": 7,
     "name": "Ficheiro Discussão",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Arquivo Discussão",
@@ -107,6 +117,7 @@
   "MediaWiki": {
     "id": 8,
     "name": "MediaWiki",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -115,6 +126,7 @@
   "MediaWiki talk": {
     "id": 9,
     "name": "MediaWiki Discussão",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -123,6 +135,7 @@
   "Template": {
     "id": 10,
     "name": "Predefinição",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -131,6 +144,7 @@
   "Template talk": {
     "id": 11,
     "name": "Predefinição Discussão",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -139,6 +153,7 @@
   "Help": {
     "id": 12,
     "name": "Ajuda",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -147,6 +162,7 @@
   "Help talk": {
     "id": 13,
     "name": "Ajuda Discussão",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -155,6 +171,7 @@
   "Category": {
     "id": 14,
     "name": "Categoria",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -163,6 +180,7 @@
   "Category talk": {
     "id": 15,
     "name": "Categoria Discussão",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -171,6 +189,7 @@
   "Appendix": {
     "id": 100,
     "name": "Apêndice",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -179,6 +198,7 @@
   "Appendix talk": {
     "id": 101,
     "name": "Apêndice Discussão",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -187,6 +207,7 @@
   "Vocabulary": {
     "id": 102,
     "name": "Vocabulário",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -195,6 +216,7 @@
   "Vocabulary talk": {
     "id": 103,
     "name": "Vocabulário Discussão",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -203,6 +225,7 @@
   "Rhymes": {
     "id": 104,
     "name": "Rimas",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -211,6 +234,7 @@
   "Rhymes talk": {
     "id": 105,
     "name": "Rimas Discussão",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -219,6 +243,7 @@
   "Portal": {
     "id": 106,
     "name": "Portal",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -227,6 +252,7 @@
   "Portal talk": {
     "id": 107,
     "name": "Portal Discussão",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -235,6 +261,7 @@
   "Citations": {
     "id": 108,
     "name": "Citações",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -243,6 +270,7 @@
   "Citations talk": {
     "id": 109,
     "name": "Citações Discussão",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -251,6 +279,7 @@
   "TimedText": {
     "id": 710,
     "name": "TimedText",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -259,6 +288,7 @@
   "TimedText talk": {
     "id": 711,
     "name": "TimedText talk",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -267,6 +297,7 @@
   "Module": {
     "id": 828,
     "name": "Módulo",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -275,6 +306,7 @@
   "Module talk": {
     "id": 829,
     "name": "Módulo Discussão",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,

--- a/src/wikitextprocessor/data/ru/namespaces.json
+++ b/src/wikitextprocessor/data/ru/namespaces.json
@@ -2,6 +2,7 @@
   "Media": {
     "id": -2,
     "name": "Медиа",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -10,6 +11,7 @@
   "Special": {
     "id": -1,
     "name": "Служебная",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -18,6 +20,7 @@
   "Main": {
     "id": 0,
     "name": "Main",
+    "subpages": false,
     "content": true,
     "aliases": [],
     "issubject": true,
@@ -26,6 +29,7 @@
   "Talk": {
     "id": 1,
     "name": "Обсуждение",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -34,6 +38,7 @@
   "User": {
     "id": 2,
     "name": "Участник",
+    "subpages": true,
     "content": false,
     "aliases": [
       "U",
@@ -46,6 +51,7 @@
   "User talk": {
     "id": 3,
     "name": "Обсуждение участника",
+    "subpages": true,
     "content": false,
     "aliases": [
       "UT",
@@ -58,6 +64,7 @@
   "Project": {
     "id": 4,
     "name": "Викисловарь",
+    "subpages": true,
     "content": false,
     "aliases": [
       "WT",
@@ -70,6 +77,7 @@
   "Project talk": {
     "id": 5,
     "name": "Обсуждение Викисловаря",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Wiktionary talk"
@@ -80,6 +88,7 @@
   "File": {
     "id": 6,
     "name": "Файл",
+    "subpages": false,
     "content": false,
     "aliases": [
       "Image",
@@ -91,6 +100,7 @@
   "File talk": {
     "id": 7,
     "name": "Обсуждение файла",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Image talk",
@@ -102,6 +112,7 @@
   "MediaWiki": {
     "id": 8,
     "name": "MediaWiki",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -110,6 +121,7 @@
   "MediaWiki talk": {
     "id": 9,
     "name": "Обсуждение MediaWiki",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -118,6 +130,7 @@
   "Template": {
     "id": 10,
     "name": "Шаблон",
+    "subpages": true,
     "content": false,
     "aliases": [
       "T",
@@ -129,6 +142,7 @@
   "Template talk": {
     "id": 11,
     "name": "Обсуждение шаблона",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -137,6 +151,7 @@
   "Help": {
     "id": 12,
     "name": "Справка",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -145,6 +160,7 @@
   "Help talk": {
     "id": 13,
     "name": "Обсуждение справки",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -153,6 +169,7 @@
   "Category": {
     "id": 14,
     "name": "Категория",
+    "subpages": false,
     "content": false,
     "aliases": [
       "К"
@@ -163,6 +180,7 @@
   "Category talk": {
     "id": 15,
     "name": "Обсуждение категории",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -171,6 +189,7 @@
   "Приложение": {
     "id": 100,
     "name": "Приложение",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Appendix"
@@ -181,6 +200,7 @@
   "Обсуждение приложения": {
     "id": 101,
     "name": "Обсуждение приложения",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Appendix talk"
@@ -191,6 +211,7 @@
   "Конкорданс": {
     "id": 102,
     "name": "Конкорданс",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Concordance"
@@ -201,6 +222,7 @@
   "Обсуждение конкорданса": {
     "id": 103,
     "name": "Обсуждение конкорданса",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Concordance talk"
@@ -211,6 +233,7 @@
   "Индекс": {
     "id": 104,
     "name": "Индекс",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Index"
@@ -221,6 +244,7 @@
   "Обсуждение индекса": {
     "id": 105,
     "name": "Обсуждение индекса",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Index talk"
@@ -231,6 +255,7 @@
   "Рифмы": {
     "id": 106,
     "name": "Рифмы",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Rhymes"
@@ -241,6 +266,7 @@
   "Обсуждение рифм": {
     "id": 107,
     "name": "Обсуждение рифм",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Rhymes talk"
@@ -251,6 +277,7 @@
   "TimedText": {
     "id": 710,
     "name": "TimedText",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -259,6 +286,7 @@
   "TimedText talk": {
     "id": 711,
     "name": "TimedText talk",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -267,6 +295,7 @@
   "Module": {
     "id": 828,
     "name": "Модуль",
+    "subpages": true,
     "content": false,
     "aliases": [
       "М"
@@ -277,6 +306,7 @@
   "Module talk": {
     "id": 829,
     "name": "Обсуждение модуля",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,

--- a/src/wikitextprocessor/data/simple/namespaces.json
+++ b/src/wikitextprocessor/data/simple/namespaces.json
@@ -2,6 +2,7 @@
   "Media": {
     "id": -2,
     "name": "Media",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -10,6 +11,7 @@
   "Special": {
     "id": -1,
     "name": "Special",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -18,6 +20,7 @@
   "Main": {
     "id": 0,
     "name": "Main",
+    "subpages": false,
     "content": true,
     "aliases": [],
     "issubject": true,
@@ -26,6 +29,7 @@
   "Talk": {
     "id": 1,
     "name": "Talk",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -34,6 +38,7 @@
   "User": {
     "id": 2,
     "name": "User",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -42,6 +47,7 @@
   "User talk": {
     "id": 3,
     "name": "User talk",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -50,6 +56,7 @@
   "Project": {
     "id": 4,
     "name": "Wiktionary",
+    "subpages": true,
     "content": false,
     "aliases": [
       "WT"
@@ -60,6 +67,7 @@
   "Project talk": {
     "id": 5,
     "name": "Wiktionary talk",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -68,6 +76,7 @@
   "File": {
     "id": 6,
     "name": "File",
+    "subpages": false,
     "content": false,
     "aliases": [
       "Image"
@@ -78,6 +87,7 @@
   "File talk": {
     "id": 7,
     "name": "File talk",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Image talk"
@@ -88,6 +98,7 @@
   "MediaWiki": {
     "id": 8,
     "name": "MediaWiki",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -96,6 +107,7 @@
   "MediaWiki talk": {
     "id": 9,
     "name": "MediaWiki talk",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -104,6 +116,7 @@
   "Template": {
     "id": 10,
     "name": "Template",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -112,6 +125,7 @@
   "Template talk": {
     "id": 11,
     "name": "Template talk",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -120,6 +134,7 @@
   "Help": {
     "id": 12,
     "name": "Help",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -128,6 +143,7 @@
   "Help talk": {
     "id": 13,
     "name": "Help talk",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -136,6 +152,7 @@
   "Category": {
     "id": 14,
     "name": "Category",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -144,6 +161,7 @@
   "Category talk": {
     "id": 15,
     "name": "Category talk",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -152,6 +170,7 @@
   "TimedText": {
     "id": 710,
     "name": "TimedText",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -160,6 +179,7 @@
   "TimedText talk": {
     "id": 711,
     "name": "TimedText talk",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -168,6 +188,7 @@
   "Module": {
     "id": 828,
     "name": "Module",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -176,6 +197,7 @@
   "Module talk": {
     "id": 829,
     "name": "Module talk",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,

--- a/src/wikitextprocessor/data/th/namespaces.json
+++ b/src/wikitextprocessor/data/th/namespaces.json
@@ -2,6 +2,7 @@
   "Media": {
     "id": -2,
     "name": "สื่อ",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -10,6 +11,7 @@
   "Special": {
     "id": -1,
     "name": "พิเศษ",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -18,6 +20,7 @@
   "Main": {
     "id": 0,
     "name": "Main",
+    "subpages": false,
     "content": true,
     "aliases": [],
     "issubject": true,
@@ -26,6 +29,7 @@
   "Talk": {
     "id": 1,
     "name": "พูดคุย",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -34,6 +38,7 @@
   "User": {
     "id": 2,
     "name": "ผู้ใช้",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -42,6 +47,7 @@
   "User talk": {
     "id": 3,
     "name": "คุยกับผู้ใช้",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -50,6 +56,7 @@
   "Project": {
     "id": 4,
     "name": "วิกิพจนานุกรม",
+    "subpages": true,
     "content": false,
     "aliases": [
       "WT",
@@ -61,6 +68,7 @@
   "Project talk": {
     "id": 5,
     "name": "คุยเรื่องวิกิพจนานุกรม",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Wiktionary talk",
@@ -72,6 +80,7 @@
   "File": {
     "id": 6,
     "name": "ไฟล์",
+    "subpages": false,
     "content": false,
     "aliases": [
       "Image",
@@ -83,6 +92,7 @@
   "File talk": {
     "id": 7,
     "name": "คุยเรื่องไฟล์",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Image talk",
@@ -94,6 +104,7 @@
   "MediaWiki": {
     "id": 8,
     "name": "มีเดียวิกิ",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -102,6 +113,7 @@
   "MediaWiki talk": {
     "id": 9,
     "name": "คุยเรื่องมีเดียวิกิ",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -110,6 +122,7 @@
   "Template": {
     "id": 10,
     "name": "แม่แบบ",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -118,6 +131,7 @@
   "Template talk": {
     "id": 11,
     "name": "คุยเรื่องแม่แบบ",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -126,6 +140,7 @@
   "Help": {
     "id": 12,
     "name": "วิธีใช้",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -134,6 +149,7 @@
   "Help talk": {
     "id": 13,
     "name": "คุยเรื่องวิธีใช้",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -142,6 +158,7 @@
   "Category": {
     "id": 14,
     "name": "หมวดหมู่",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -150,6 +167,7 @@
   "Category talk": {
     "id": 15,
     "name": "คุยเรื่องหมวดหมู่",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -158,6 +176,7 @@
   "Appendix": {
     "id": 100,
     "name": "ภาคผนวก",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -166,6 +185,7 @@
   "Appendix talk": {
     "id": 101,
     "name": "คุยเรื่องภาคผนวก",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -174,6 +194,7 @@
   "Index": {
     "id": 102,
     "name": "ดัชนี",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -182,6 +203,7 @@
   "Index talk": {
     "id": 103,
     "name": "คุยเรื่องดัชนี",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -190,6 +212,7 @@
   "Rhymes": {
     "id": 104,
     "name": "สัมผัส",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Rhymes"
@@ -200,6 +223,7 @@
   "Rhymes talk": {
     "id": 105,
     "name": "คุยเรื่องสัมผัส",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Rhymes talk"
@@ -210,6 +234,7 @@
   "Thesaurus": {
     "id": 110,
     "name": "อรรถาภิธาน",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -218,6 +243,7 @@
   "Thesaurus talk": {
     "id": 111,
     "name": "คุยเรื่องอรรถาภิธาน",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -226,6 +252,7 @@
   "TimedText": {
     "id": 710,
     "name": "TimedText",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -234,6 +261,7 @@
   "TimedText talk": {
     "id": 711,
     "name": "TimedText talk",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -242,6 +270,7 @@
   "Module": {
     "id": 828,
     "name": "มอดูล",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -250,6 +279,7 @@
   "Module talk": {
     "id": 829,
     "name": "คุยเรื่องมอดูล",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,

--- a/src/wikitextprocessor/data/zh/namespaces.json
+++ b/src/wikitextprocessor/data/zh/namespaces.json
@@ -2,11 +2,15 @@
   "Media": {
     "id": -2,
     "name": "Media",
+    "subpages": false,
     "content": false,
     "aliases": [
       "媒体",
       "媒体文件",
-      "媒體"
+      "媒体档案",
+      "媒體",
+      "媒體文件",
+      "媒體檔案"
     ],
     "issubject": true,
     "istalk": false
@@ -14,6 +18,7 @@
   "Special": {
     "id": -1,
     "name": "Special",
+    "subpages": false,
     "content": false,
     "aliases": [
       "特殊"
@@ -24,6 +29,7 @@
   "Main": {
     "id": 0,
     "name": "Main",
+    "subpages": false,
     "content": true,
     "aliases": [],
     "issubject": true,
@@ -32,6 +38,7 @@
   "Talk": {
     "id": 1,
     "name": "Talk",
+    "subpages": true,
     "content": false,
     "aliases": [
       "对话",
@@ -45,8 +52,10 @@
   "User": {
     "id": 2,
     "name": "User",
+    "subpages": true,
     "content": false,
     "aliases": [
+      "使用者",
       "用戶",
       "用户"
     ],
@@ -56,8 +65,13 @@
   "User talk": {
     "id": 3,
     "name": "User talk",
+    "subpages": true,
     "content": false,
     "aliases": [
+      "使用者对话",
+      "使用者對話",
+      "使用者討論",
+      "使用者讨论",
       "用戶對話",
       "用戶討論",
       "用户对话",
@@ -69,9 +83,12 @@
   "Project": {
     "id": 4,
     "name": "Wiktionary",
+    "subpages": true,
     "content": false,
     "aliases": [
       "WT",
+      "专案",
+      "專案",
       "維基詞典",
       "维基词典"
     ],
@@ -81,8 +98,15 @@
   "Project talk": {
     "id": 5,
     "name": "Wiktionary talk",
+    "subpages": true,
     "content": false,
     "aliases": [
+      "Wiktionary对话",
+      "Wiktionary對話",
+      "Wiktionary討論",
+      "Wiktionary讨论",
+      "专案讨论",
+      "專案討論",
       "維基詞典討論",
       "维基词典讨论"
     ],
@@ -92,10 +116,12 @@
   "File": {
     "id": 6,
     "name": "File",
+    "subpages": false,
     "content": false,
     "aliases": [
       "Image",
       "图像",
+      "图片",
       "圖像",
       "圖片",
       "文件",
@@ -108,11 +134,13 @@
   "File talk": {
     "id": 7,
     "name": "File talk",
+    "subpages": true,
     "content": false,
     "aliases": [
       "Image talk",
       "图像对话",
       "图像讨论",
+      "图片讨论",
       "圖像對話",
       "圖像討論",
       "圖片討論",
@@ -131,6 +159,7 @@
   "MediaWiki": {
     "id": 8,
     "name": "MediaWiki",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -139,6 +168,7 @@
   "MediaWiki talk": {
     "id": 9,
     "name": "MediaWiki talk",
+    "subpages": true,
     "content": false,
     "aliases": [
       "MediaWiki討論",
@@ -150,6 +180,7 @@
   "Template": {
     "id": 10,
     "name": "Template",
+    "subpages": true,
     "content": false,
     "aliases": [
       "T",
@@ -163,6 +194,7 @@
   "Template talk": {
     "id": 11,
     "name": "Template talk",
+    "subpages": true,
     "content": false,
     "aliases": [
       "样板对话",
@@ -180,10 +212,15 @@
   "Help": {
     "id": 12,
     "name": "Help",
+    "subpages": true,
     "content": false,
     "aliases": [
+      "使用說明",
+      "使用说明",
       "帮助",
-      "幫助"
+      "幫助",
+      "說明",
+      "说明"
     ],
     "issubject": true,
     "istalk": false
@@ -191,12 +228,17 @@
   "Help talk": {
     "id": 13,
     "name": "Help talk",
+    "subpages": true,
     "content": false,
     "aliases": [
+      "使用說明討論",
+      "使用说明讨论",
       "帮助对话",
       "帮助讨论",
       "幫助對話",
-      "幫助討論"
+      "幫助討論",
+      "說明討論",
+      "说明讨论"
     ],
     "issubject": false,
     "istalk": true
@@ -204,6 +246,7 @@
   "Category": {
     "id": 14,
     "name": "Category",
+    "subpages": false,
     "content": false,
     "aliases": [
       "CAT",
@@ -216,6 +259,7 @@
   "Category talk": {
     "id": 15,
     "name": "Category talk",
+    "subpages": true,
     "content": false,
     "aliases": [
       "分类对话",
@@ -229,6 +273,7 @@
   "Appendix": {
     "id": 100,
     "name": "Appendix",
+    "subpages": true,
     "content": false,
     "aliases": [
       "附录",
@@ -240,6 +285,7 @@
   "Appendix talk": {
     "id": 101,
     "name": "Appendix talk",
+    "subpages": true,
     "content": false,
     "aliases": [
       "附录讨论",
@@ -251,6 +297,7 @@
   "Transwiki": {
     "id": 102,
     "name": "Transwiki",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -259,6 +306,7 @@
   "Transwiki talk": {
     "id": 103,
     "name": "Transwiki talk",
+    "subpages": true,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -267,6 +315,7 @@
   "Rhymes": {
     "id": 106,
     "name": "Rhymes",
+    "subpages": true,
     "content": false,
     "aliases": [
       "韵部",
@@ -278,6 +327,7 @@
   "Rhymes talk": {
     "id": 107,
     "name": "Rhymes talk",
+    "subpages": true,
     "content": false,
     "aliases": [
       "韵部讨论",
@@ -289,6 +339,7 @@
   "Thesaurus": {
     "id": 110,
     "name": "Thesaurus",
+    "subpages": true,
     "content": false,
     "aliases": [
       "类义词库",
@@ -302,6 +353,7 @@
   "Thesaurus talk": {
     "id": 111,
     "name": "Thesaurus talk",
+    "subpages": true,
     "content": false,
     "aliases": [
       "类义词库讨论",
@@ -315,6 +367,7 @@
   "Citations": {
     "id": 114,
     "name": "Citations",
+    "subpages": true,
     "content": false,
     "aliases": [
       "引文"
@@ -325,6 +378,7 @@
   "Citations talk": {
     "id": 115,
     "name": "Citations talk",
+    "subpages": true,
     "content": false,
     "aliases": [
       "引文討論",
@@ -336,6 +390,7 @@
   "Reconstruction": {
     "id": 118,
     "name": "Reconstruction",
+    "subpages": true,
     "content": false,
     "aliases": [
       "RC",
@@ -349,6 +404,7 @@
   "Reconstruction talk": {
     "id": 119,
     "name": "Reconstruction talk",
+    "subpages": true,
     "content": false,
     "aliases": [
       "重建討論",
@@ -362,6 +418,7 @@
   "TimedText": {
     "id": 710,
     "name": "TimedText",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": true,
@@ -370,6 +427,7 @@
   "TimedText talk": {
     "id": 711,
     "name": "TimedText talk",
+    "subpages": false,
     "content": false,
     "aliases": [],
     "issubject": false,
@@ -378,6 +436,7 @@
   "Module": {
     "id": 828,
     "name": "Module",
+    "subpages": true,
     "content": false,
     "aliases": [
       "模块",
@@ -391,6 +450,7 @@
   "Module talk": {
     "id": 829,
     "name": "Module talk",
+    "subpages": true,
     "content": false,
     "aliases": [
       "模块对话",
@@ -402,38 +462,6 @@
       "模组对话",
       "模组讨论"
     ],
-    "issubject": false,
-    "istalk": true
-  },
-  "Gadget": {
-    "id": 2300,
-    "name": "Gadget",
-    "content": false,
-    "aliases": [],
-    "issubject": true,
-    "istalk": false
-  },
-  "Gadget talk": {
-    "id": 2301,
-    "name": "Gadget talk",
-    "content": false,
-    "aliases": [],
-    "issubject": false,
-    "istalk": true
-  },
-  "Gadget definition": {
-    "id": 2302,
-    "name": "Gadget definition",
-    "content": false,
-    "aliases": [],
-    "issubject": true,
-    "istalk": false
-  },
-  "Gadget definition talk": {
-    "id": 2303,
-    "name": "Gadget definition talk",
-    "content": false,
-    "aliases": [],
     "issubject": false,
     "istalk": true
   }

--- a/src/wikitextprocessor/lua/mw_site.lua
+++ b/src/wikitextprocessor/lua/mw_site.lua
@@ -23,7 +23,6 @@ function Namespace:new(obj)
    setmetatable(obj, self)
    obj.canonicalName = obj.canonical
    obj.displayName = obj.name
-   obj.hasSubpages = obj.name == "Main" or obj.name == NAMESPACE_DATA.Module.name
    return obj
 end
 
@@ -43,6 +42,7 @@ for ns_canonical_name in pairs(NAMESPACE_DATA) do
     isTalk=ns_data.istalk,
     aliases=ns_data.aliases,
     canonical=ns_canonical_name,
+    hasSubpages=ns_data.subpages,
   }
   mw_site_namespaces[ns_data.id] = ns
   mw_site_namespaces[ns_data.name] = ns

--- a/src/wikitextprocessor/lua/mw_title.lua
+++ b/src/wikitextprocessor/lua/mw_title.lua
@@ -196,7 +196,9 @@ function mw_title.makeTitle(namespace, title, fragment, interwiki)
     end
 
     -- Copided from: https://github.com/wikimedia/mediawiki-extensions-Scribunto/blob/2ee5768ef565965cf5a5057233c557b281aaa837/includes/Engines/LuaCommon/lualib/mw.title.lua#L85
-    local firstSlash, lastSlash = string.match(title, '^[^/]*().*()/[^/]*$')
+    if not ns.name == "Main" then
+        local firstSlash, lastSlash = string.match(title, '^[^/]*().*()/[^/]*$')
+    end
     local isSubpage, rootText, baseText, subpageText
     if firstSlash then
         isSubpage = true

--- a/src/wikitextprocessor/lua/mw_title.lua
+++ b/src/wikitextprocessor/lua/mw_title.lua
@@ -196,8 +196,9 @@ function mw_title.makeTitle(namespace, title, fragment, interwiki)
     end
 
     -- Copided from: https://github.com/wikimedia/mediawiki-extensions-Scribunto/blob/2ee5768ef565965cf5a5057233c557b281aaa837/includes/Engines/LuaCommon/lualib/mw.title.lua#L85
-    if not ns.name == "Main" then
-        local firstSlash, lastSlash = string.match(title, '^[^/]*().*()/[^/]*$')
+    local firstSlash, lastSlash
+    if ns.hasSubpages then
+        firstSlash, lastSlash = string.match(title, '^[^/]*().*()/[^/]*$')
     end
     local isSubpage, rootText, baseText, subpageText
     if firstSlash then

--- a/tests/test_wikiprocess.py
+++ b/tests/test_wikiprocess.py
@@ -3752,7 +3752,7 @@ return export
 
     def test_mw_title47(self):
         self.scribunto(
-            "Test/foo",
+            "Test/foo/bar",
             r"""
         local t = mw.title.makeTitle("Main", "Test/foo/bar", "Frag")
         return t.basePageTitle.fullText""",
@@ -3760,7 +3760,7 @@ return export
 
     def test_mw_title48(self):
         self.scribunto(
-            "Test",
+            "Test/foo/bar",
             r"""
         local t = mw.title.makeTitle("Main", "Test/foo/bar", "Frag")
         return t.rootPageTitle.fullText""",

--- a/tools/get_namespaces.py
+++ b/tools/get_namespaces.py
@@ -20,7 +20,7 @@ def get_namespace_data(domain, siprop):
     return r.json()
 
 
-SAVED_KEYS = {"id", "name", "content", "canonical"}
+SAVED_KEYS = {"id", "name", "content", "canonical", "subpages"}
 
 
 def main():


### PR DESCRIPTION
Wiktextract issue https://github.com/tatuylonen/wiktextract/issues/1009

Pagename data passed into templates or modules was split on slashes, so you'd get output like `Bing`
and `Bed` instead of `A/Bing` and `A/Bed`.

We had some copied code from Scribunto handling
slashes in titles, but it didn't do a check for
whether slashes should be considered 'subpages',
like Module:mainmodule/submodule. `Main:` which
is our main concern, doesn't have subpages and
slashes should be considered part of the title.

I've only done a quick and dirty fix here, because we only concern ourselves with Main:, Template:
and Module:; All other should hopefully have
subpages (default assumption except for Main:)
or not have slashes in their titles.