### PR TITLE
[ku] remove LanguageConverter markups for ku edition

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -1594,7 +1594,7 @@ class Wtp:
         # Remove LanguageConverter markups:
         # https://www.mediawiki.org/wiki/Writing_systems/Syntax
         # but ignore `-{}-` template argument placeholder: #59
-        if not pre_expand and self.lang_code == "zh" and text != "-{}-":
+        if not pre_expand and self.lang_code in ["zh", "ku"] and text != "-{}-":
             expanded = expanded.replace("-{", "").replace("}-", "")
 
         return expanded


### PR DESCRIPTION
Maybe this code could be moved to wiktextract package's `clean_node()`?