### PR TITLE
Greek wiktionary uses '0', '00' and '000' as parameters

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -1212,7 +1212,7 @@ class Wtp:
                             expand_args(args[0], argmap), parent, True
                         ).strip()
                         self.expand_stack.pop()
-                        if k.isdigit():
+                        if k.isdigit() and int(k) > 0:
                             k = int(k)
                         else:
                             k = re.sub(r"\s+", " ", k).strip()
@@ -1428,7 +1428,7 @@ class Wtp:
                             # https://en.wikipedia.org/wiki/Help:Template
                             # (but not around unnamed parameters)
                             k, arg = m2.groups()
-                            if k.isdigit():
+                            if k.isdigit() and int(k) > 0:
                                 k = int(k)
                             else:
                                 self.expand_stack.append("ARGNAME")

--- a/src/wikitextprocessor/parser.py
+++ b/src/wikitextprocessor/parser.py
@@ -632,7 +632,10 @@ class TemplateNode(WikiNode):
                             parameter_value = parameter[
                                 equal_sign_index + 1 :
                             ].strip()
-                            if parameter_name.isdigit():  # value contains "="
+                            if (
+                                parameter_name.isdigit()
+                                and int(parameter_name) > 0
+                            ):  # value contains "="
                                 parameter_name = int(parameter_name)
                                 is_named = False
                             if len(parameter_value) > 0:

--- a/tests/test_lua.py
+++ b/tests/test_lua.py
@@ -598,3 +598,45 @@ end
 return export""",
         )
         self.assertEqual(self.wtp.expand("{{#invoke:test|test}}"), "**")
+
+    def test_el_zero_arg(self):
+        # https://el.wiktionary.org/wiki/Πρότυπο:ετ
+        # Unnamed template parameters and numbered parameters can only
+        # be positive non-zero integers; zero or "00" or negative is a string
+        self.wtp.start_page("θηλυκός")
+        self.wtp.add_page(
+            "Module:test",
+            828,
+            """local export = {}
+function export.test(frame)
+  return tostring(frame.args['0']) .. "|" ..
+         --tostring(frame.args[0]) .. "|" ..
+         tostring(frame.args['00']) .. "|" ..
+         tostring(frame.args[1]) .. "|" ..
+         tostring(frame.args[2]) .. "|" ..
+         tostring(frame.args['named'])
+end
+return export""",
+        )
+        self.assertEqual(
+            self.wtp.expand(
+                "{{#invoke:test|test|0= 0 |00= 00 | first |2= second |named= named }}"  # noqa: E501
+            ),
+            "0|00| first |second|named",
+        )
+
+    def test_el_strip_arg(self):
+        self.wtp.start_page("θηλυκός")
+        self.wtp.add_page(
+            "Module:test",
+            828,
+            """local export = {}
+function export.test(frame)
+  return tostring(frame.args['foo'])
+end
+return export""",
+        )
+        self.assertEqual(
+            self.wtp.expand("{{#invoke:test|test|foo=  {{#if||}} {{#if||}} }}"),
+            "",
+        )


### PR DESCRIPTION
https://el.wiktionary.org/w/index.php?title=%CE%A0%CF%81%CF%8C%CF%84%CF%85%CF%80%CE%BF:%CE%B5%CF%84

```
-->|0={{{0|}}} <!-- no parenthesis 
-->|00={{{00|}}} {{#if:{{{nocat|}}}|{{{nocat|}}}}}<!--
-->|000={{{000|}}} {{#if:{{{nodisplay|}}}|{{{nodisplay|}}}}}<!--
```

Apparently parameter names under 1, like '0' or '00' aren't changed to integers... Or that Scribunto handles all parameter names as strings and just does something special with the indexing stuff.

Still need to figure out some things...