### PR TITLE
Don't skip redirect pages in `Wtp.analyze_templates()`

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -944,13 +944,12 @@ class Wtp:
         included_map: defaultdict[str, set[str]] = defaultdict(set)
 
         for page in self.get_all_pages([template_ns_id]):
-            if page.body is not None:
-                used_templates, pre_expand = check_template_func(self, page)
-                for used_template in used_templates:
-                    included_map[used_template].add(page.title)
-                if pre_expand:
-                    self.set_template_pre_expand(page.title)
-                    expand_stack.append(page)
+            used_templates, pre_expand = check_template_func(self, page)
+            for used_template in used_templates:
+                included_map[used_template].add(page.title)
+            if pre_expand:
+                self.set_template_pre_expand(page.title)
+                expand_stack.append(page)
 
         # XXX consider encoding template bodies here (also need to save related
         # cookies).  This could speed up their expansion, where the first


### PR DESCRIPTION
Most non-en editions only check template names. "Template:-vi-" in id edition redirect to a language section template.