### PR TITLE
Fixed bug with `#switch` parser function `#default`

### DIFF
--- a/src/wikitextprocessor/parserfns.py
+++ b/src/wikitextprocessor/parserfns.py
@@ -108,6 +108,7 @@ def switch_fn(
     """Implements #switch parser function."""
     val = expander(args[0]).strip() if args else ""
     match_next = False
+    next_val_is_default = False
     defval: Optional[str] = None
     last: Optional[str] = None
     for i in range(1, len(args)):
@@ -117,12 +118,18 @@ def switch_fn(
             last = expander(arg).strip()
             if last == val:
                 match_next = True
+            if last.lower() == "#default":
+                next_val_is_default = True
             continue
         k, v = m.groups()
+        if next_val_is_default is True and v:
+            defval = v
+            next_val_is_default = False
         k = expander(k).strip()
         if k == val or match_next:
             return expander(v).strip()
         if k.lower() == "#default":
+            # No need to touch next_val_is_default, v is guaranteed
             defval = v
         last = None
     if defval is not None:

--- a/tests/test_wikiprocess.py
+++ b/tests/test_wikiprocess.py
@@ -334,6 +334,12 @@ return export
     def test_switch6(self):
         self.parserfn("{{#switch:b|a=one|#default=three|b=two}}", "two")
 
+    def test_switch6b(self):
+        self.parserfn("{{#switch:|a=one|#default|b=three|c=two}}", "three")
+
+    def test_switch6c(self):
+        self.parserfn("{{#switch:b|a=one|#default|b=three|c=two}}", "three")
+
     def test_switch7(self):
         self.parserfn("{{#switch:c|a=one|c|d=four|b=two}}", "four")
 


### PR DESCRIPTION
Fixes #369

Turns out that if you have a switch statement like

`{{#switch:|a=one|#default|b=three|c=two}}`

the default option will be "three". Previously, we assumed that `#default` would only appear with an assignment, like `#default=foo`, but it can be part of a chain.