### PR TITLE
Fix bug with unclosed bold and italics in succession

### DIFF
--- a/src/wikitextprocessor/parser.py
+++ b/src/wikitextprocessor/parser.py
@@ -967,6 +967,7 @@ def text_fn(ctx: "Wtp", token: str) -> None:
                     sortid="parser/449",
                 )
                 _parser_pop(ctx, False)
+                continue
             break
 
         # Spaces at the beginning of a line indicate preformatted text
@@ -2241,9 +2242,9 @@ def token_iter(ctx: "Wtp", text: str) -> Iterator[tuple[bool, str]]:
                 # the length is longer than the end token was.
                 yield True, ">" + start
             continue
-        # Partition on '', so that we can detect bold/italics
+        # Partition on ''+, so that we can detect bold/italics
         parts = re.split(parts_re, line)
-        state = 0  # 1=in italic 2=in bold 3=in both
+        state = 0  # 1=in italic, 2=in bold, 3=in both
         for i, part in enumerate(parts):
             if part.startswith("''"):
                 # This is a bold/italic part.  Scan the rest of the line


### PR DESCRIPTION
Fixes wiktextract issue #1120 and others

What was broken: if you had text like `aaa '''bolded''` with a typo that makes the formatters unbalanced,
the earlier token would eat the rest of the article.

Issue was fixed by adding `continue` into text_fn() in parser.py, in the `while True` block that would loop over the current parser stack in reverse and pop its items, to handle end-of-line breakpoints for those items.

The `elif` entry for italics and bolds were missing a continue, and so the `break` after the `if` block would execute, meaning the bold token was never popped and parsing continued with everything following being its children.

Also, I just spent too damn long trying to figure out why `python -m unittest` was stuck (couldn't even kill it with SIGINT)... It was because my uncommitted debugging code had `breakpoint()`, which of course opened the python debugger in the background of certain tests... I don't use the pdb enough for this to not be a surprise.