### PR TITLE
Don't parse template as parser function

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -1344,9 +1344,7 @@ class Wtp:
                         # It might be a parser function call
                         fn_name = self._canonicalize_parserfn_name(tname[:ofs])
                         # Check if it is a recognized parser function name
-                        if fn_name in PARSER_FUNCTIONS or fn_name.startswith(
-                            "#"
-                        ):
+                        if self.is_parser_function(fn_name):
                             self.expand_stack.append(fn_name)
                             ret = expand_parserfn(
                                 fn_name, (tname[ofs + 1 :].lstrip(),) + args[1:]
@@ -1361,7 +1359,7 @@ class Wtp:
                     # for magic words and some parser functions have an implicit
                     # compatibility template that essentially does this.
                     fn_name = self._canonicalize_parserfn_name(tname)
-                    if fn_name in PARSER_FUNCTIONS or fn_name.startswith("#"):
+                    if self.is_parser_function(fn_name):
                         ret = expand_parserfn(fn_name, args[1:])
                         parts.append(ret)
                         continue
@@ -1930,6 +1928,15 @@ class Wtp:
                 self.strip_marker_cache["preprocess"] += 1
                 self.strip_marker_cache[content] = num
         return f"""\x7f'"`UNIQ--{node}-{num_str}-QINU`"'\x7f"""
+
+    def is_parser_function(self, template_name: str) -> bool:
+        if self.page_exists(
+            template_name, self.NAMESPACE_DATA["Template"]["id"]
+        ):
+            return False
+        return template_name in PARSER_FUNCTIONS or template_name.startswith(
+            "#"
+        )
 
 
 def detect_expand_template_loop(stack: list[str]) -> bool:

--- a/src/wikitextprocessor/parser.py
+++ b/src/wikitextprocessor/parser.py
@@ -827,7 +827,7 @@ def _parser_pop(ctx: "Wtp", warn_unclosed: bool) -> None:
         and node.largs
         and len(node.largs[0]) == 1
         and isinstance(node.largs[0][0], str)
-        and node.largs[0][0] in PARSER_FUNCTIONS
+        and ctx.is_parser_function(node.largs[0][0])
     ):
         # Change node type to PARSER_FN.  Otherwise it has identical
         # structure to a TEMPLATE.

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2610,6 +2610,7 @@ foo
         # https://en.wiktionary.org/wiki/落葉歸根
         wikitext = "{{zh-x|3=CL|葉落歸根，來 時 無 口。||ref=宋·釋道原《景德傳燈錄》|collapsed=y}}"  # noqa: E501
         self.ctx.start_page("落葉歸根")
+        self.ctx.add_page("Template:zh-x", 10, "{{{1}}}")
         tree = self.ctx.parse(wikitext)
         template_node = tree.children[0]
         self.assertTrue(isinstance(template_node, TemplateNode))
@@ -2624,7 +2625,6 @@ foo
                 "collapsed": "y",
             },
         )
-        self.ctx.add_page("Template:zh-x", 10, "{{{1}}}")
         self.assertEqual(self.ctx.expand(wikitext), "葉落歸根，來 時 無 口。")
 
     def test_level_1_header(self):
@@ -3169,6 +3169,14 @@ text
         self.assertEqual(root.children[0].kind, NodeKind.BOLD)
         self.assertEqual(root.children[0].children[1].kind, NodeKind.ITALIC)
         self.assertEqual(root.children[2].kind, NodeKind.LEVEL3)
+
+    def test_not_parser_function_template(self):
+        # https://es.wiktionary.org/wiki/gatos
+        self.ctx.start_page("gotos")
+        self.ctx.add_page("Template:plural", 10, "text")
+        root = self.ctx.parse("{{plural}}")
+        self.assertIsInstance(root.children[0], TemplateNode)
+        self.assertEqual(self.ctx.node_to_html(root), "text")
 
 
 # XXX implement <nowiki/> marking for links, templates

--- a/tests/test_wikiprocess.py
+++ b/tests/test_wikiprocess.py
@@ -199,16 +199,13 @@ return export
         )
         self.assertEqual(ret, "Aa[[:hu:állati|(hu)]]bB")
 
-    @patch(
-        "wikitextprocessor.core.Wtp.get_page",
-        return_value=Page(
-            title="Template:templ",
-            namespace_id=10,
-            body="a{{#ifeq:{{{interwiki|}}}|1|[[:{{{1}}}:{{{2}}}|({{{1}}})]]}}b",
-        ),
-    )
-    def test_basic17(self, mock_get_page):
+    def test_basic17(self):
         self.ctx.start_page("Tt")
+        self.ctx.add_page(
+            "Template:templ",
+            10,
+            "a{{#ifeq:{{{interwiki|}}}|1|[[:{{{1}}}:{{{2}}}|({{{1}}})]]}}b",
+        )
         ret = self.ctx.expand(
             "A{{templ|hu|állati|langname=Hungarian|interwiki=1}}B"
         )
@@ -307,12 +304,9 @@ return export
     def test_ifexist2(self):
         self.parserfn("{{#ifexist:Nonexxxx|T}}", "")
 
-    @patch(
-        "wikitextprocessor.core.Wtp.get_page",
-        return_value=Page(title="Test title", namespace_id=0, body="FOO"),
-    )
-    def test_ifexist3(self, mock_get_page):
+    def test_ifexist3(self):
         self.ctx.start_page("Tt")
+        self.ctx.add_page("Test title", 0, "FOO")
         ret = self.ctx.expand("{{#ifexist:Test title|T|F}}")
         self.assertEqual(ret, "T")
 
@@ -368,12 +362,12 @@ return export
         # string.
         self.parserfn("{{#categorytree:Foo|mode=all}}", "")
 
-    @patch(
-        "wikitextprocessor.core.Wtp.get_page",
-        return_value=Page(
-            title="Test title",
-            namespace_id=0,
-            body="""
+    def test_lst_fn(self):
+        self.ctx.start_page("Tt")
+        self.ctx.add_page(
+            "testpage",
+            0,
+            """
 <section begin="foo" />
 === Test section ===
 A
@@ -390,10 +384,7 @@ MORE
 NOT
 <section end="bar" />
 """,
-        ),
-    )
-    def test_lst_fn(self, mock_get_page):
-        self.ctx.start_page("Tt")
+        )
         ret = self.ctx.expand("{{#lst:testpage|foo}}")
         self.assertEqual(
             ret,


### PR DESCRIPTION
In Spanish Wiktionary, "plural" is a template