### PR TITLE
Use line number to find the matching section node

### DIFF
--- a/src/wikitextprocessor/parser.py
+++ b/src/wikitextprocessor/parser.py
@@ -1076,7 +1076,7 @@ def subtitle_end_fn(ctx: "Wtp", token: str) -> None:
     pop_count = 0
     find_start_node = False
     for parent_node in reversed(ctx.parser_stack):
-        if parent_node.kind == kind:
+        if parent_node.kind == kind and parent_node.loc == ctx.linenum:
             for _ in range(pop_count):
                 _parser_pop(ctx, True)
             find_start_node = True

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3190,6 +3190,23 @@ text
         self.assertEqual(root.children[0].kind, NodeKind.TEMPLATE)
         self.assertEqual(self.ctx.node_to_html(root), "textaaa")
 
+    def test_deformed_level_nodes(self):
+        # the section end "==" token in "{{==Türkçe==" shouldn't close the
+        # first level 2 node and move all the nodes in between to `.largs`
+        root = self.parse(
+            "deist",
+            """==Türkçe==
+====Çeviriler====
+* Almanca: {{==Türkçe==
+
+===Kaynakça===
+* {{Kaynak-TDK}}}}
+""",
+        )
+        level_2 = root.children[0]
+        self.assertEqual(level_2.kind, NodeKind.LEVEL2)
+        self.assertEqual(level_2.children[1].kind, NodeKind.LEVEL4)
+
 
 # XXX implement <nowiki/> marking for links, templates
 #  - https://en.wikipedia.org/wiki/Help:Wikitext#Nowiki


### PR DESCRIPTION
the section start and end token should be in the same line, fix #377