### PR TITLE
Downgrade dateparser 1.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "dateparser",
+    "dateparser==1.2.1",
     "lupa",
     "lxml",
     "mediawiki_langcodes",


### PR DESCRIPTION
1.2.2 has a broken pickle cache fails "test_time34".