### PR TITLE
fix: commit db changes on close

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -392,6 +392,7 @@ class Wtp:
 
     def close_db_conn(self) -> None:
         assert self.db_path
+        self.db_conn.commit()
         self.db_conn.close()
         if self.db_path.parent.samefile(Path(tempfile.gettempdir())):
             for path in self.db_path.parent.glob(self.db_path.name + "*"):


### PR DESCRIPTION
Without this change, the DB was always empty at the end of my tests for [reader.dict](https://github.com/reader-dict).