### PR TITLE
`mw.site.namespaces` dictionary should have canonical name keys

### DIFF
--- a/src/wikitextprocessor/lua/mw_site.lua
+++ b/src/wikitextprocessor/lua/mw_site.lua
@@ -46,6 +46,7 @@ for ns_canonical_name in pairs(NAMESPACE_DATA) do
   }
   mw_site_namespaces[ns_data.id] = ns
   mw_site_namespaces[ns_data.name] = ns
+  mw_site_namespaces[ns_canonical_name] = ns
 
   if ns_data.content then
     mw_site_contentNamespaces[ns_data.id] = ns

--- a/tests/test_lua.py
+++ b/tests/test_lua.py
@@ -640,3 +640,18 @@ return export""",
             self.wtp.expand("{{#invoke:test|test|foo=  {{#if||}} {{#if||}} }}"),
             "",
         )
+
+    def test_mw_site_canonical_ns_key(self):
+        # https://cs.wiktionary.org/wiki/Modul:Maintenance#L-193
+        # `mw.site.namespaces.Category.name`
+        self.wtp.start_page("")
+        self.wtp.add_page(
+            "Module:test",
+            828,
+            """local export = {}
+function export.test(frame)
+  return mw.site.namespaces.Project.name
+end
+return export""",
+        )
+        self.assertEqual(self.wtp.expand("{{#invoke:test|test}}"), "Wiktionary")


### PR DESCRIPTION
fix index nil Lua error in cs edition