### PR TITLE
Allow pipe character in external links

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -185,7 +185,7 @@ LINKS_RE = re.compile(LINKS)
 
 # Encode external links: [something]
 # [test]]+ breaks in sandbox, so prevent with negative lookahead
-EXTERNAL_LINKS = r"\[([^][{}<>|\n]+)\](?!\])"
+EXTERNAL_LINKS = r"\[([^][{}<>\n]+)\](?!\])"
 
 EXTERNAL_LINKS_RE = re.compile(EXTERNAL_LINKS)
 

--- a/src/wikitextprocessor/parser.py
+++ b/src/wikitextprocessor/parser.py
@@ -1625,8 +1625,9 @@ def vbar_fn(ctx: "Wtp", token: str) -> None:
     templates, template argument references, links, etc, and it can
     also separate table row cells."""
     node = ctx.parser_stack[-1]
-    if node.kind in HAVE_ARGS_KIND_FLAGS and node.kind is not NodeKind.URL:
-        # [http://url.com these do not use vbars, only one initial space]
+    if node.kind == NodeKind.URL:
+        text_fn(ctx, token)
+    elif node.kind in HAVE_ARGS_KIND_FLAGS:
         _parser_merge_str_children(ctx)
         node.largs.append(node.children)
         node.children = []

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3243,6 +3243,23 @@ text</ref>
         self.assertEqual(t_node.template_parameters["перевод"][0], "Она ")
         self.assertEqual(t_node.template_parameters["перевод"][2], " закон.")
 
+    def test_pipe_in_external_link(self):
+        # https://cs.wiktionary.org/wiki/veselé_Vánoce
+        self.ctx.start_page("veselé Vánoce")
+        root = self.ctx.parse(
+            "[http://learn101.org/armenian_phrases.php Armenian Phrases | learn101.org]"  # noqa:E501
+        )
+        self.assertEqual(len(root.children), 1)
+        url_node = root.children[0]
+        self.assertEqual(url_node.kind, NodeKind.URL)
+        self.assertEqual(
+            url_node.largs,
+            [
+                ["http://learn101.org/armenian_phrases.php"],
+                ["Armenian Phrases | learn101.org"],
+            ],
+        )
+
 
 # XXX implement <nowiki/> marking for links, templates
 #  - https://en.wikipedia.org/wiki/Help:Wikitext#Nowiki


### PR DESCRIPTION
fix Lua error in cs edition, "|" in external links should be parsed as plain text