### PR TITLE
Remove dateparser package version pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "dateparser==1.2.1",
+    "dateparser",
     "lupa",
     "lxml",
     "mediawiki_langcodes",


### PR DESCRIPTION
the "test_time34" test no longer fails with the latest "dateparser" and "regex" releases but no idea what causes the problem and how it's solved