### PR TITLE
`||` inside table should be parsed as one cell

### DIFF
--- a/src/wikitextprocessor/parser.py
+++ b/src/wikitextprocessor/parser.py
@@ -1655,11 +1655,13 @@ def double_vbar_fn(ctx: "Wtp", token: str) -> None:
         return
 
     # If it is at the beginning of a line, interpret it as starting a new
-    # cell, without any HTML attributes.  We do this by emitting two individual
-    # vbars.
+    # cell, without any HTML attributes.  We do this by emitting one vbar.
     if ctx.beginning_of_line and ctx.begline_enabled:
-        vbar_fn(ctx, "|")
-        vbar_fn(ctx, "|")
+        if _parser_have(ctx, NodeKind.TABLE):
+            vbar_fn(ctx, "|")
+        else:
+            vbar_fn(ctx, "|")
+            vbar_fn(ctx, "|")
         return
 
     while True:
@@ -2397,7 +2399,7 @@ def process_text(ctx: "Wtp", text: str) -> None:
                 hline_fn(ctx, token)
             elif re.match(list_prefix_re, token):
                 list_fn(ctx, token)
-            elif token.startswith("https://") or token.startswith("http://"):
+            elif token.startswith(("https://", "http://")):
                 url_fn(ctx, token)
             elif (
                 len(token) == 1

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2058,7 +2058,17 @@ foo
         self.assertEqual(b.kind, NodeKind.TABLE_HEADER_CELL)
 
     def test_table_hdr4(self):
-        tree = self.parse("test", "{|\n! Hdr\n||bar\n| |baz\n| zap\n|}")
+        # en edition page "山歩き", Template:ja-suru
+        # fr edition page "amare", Template:es-verbe-flexion
+        tree = self.parse(
+            "test",
+            """{|
+! Hdr
+||bar
+| |baz
+| zap
+|}""",
+        )
         self.assertEqual(self.ctx.errors, [])
         self.assertEqual(self.ctx.warnings, [])
         self.assertEqual(self.ctx.debugs, [])
@@ -2068,7 +2078,7 @@ foo
         self.assertEqual(len(t.children), 1)
         row = t.children[0]
         self.assertEqual(row.kind, NodeKind.TABLE_ROW)
-        self.assertEqual(len(row.children), 5)
+        self.assertEqual(len(row.children), 4)
         for c, kind in zip(
             row.children,
             [
@@ -2076,10 +2086,19 @@ foo
                 NodeKind.TABLE_CELL,
                 NodeKind.TABLE_CELL,
                 NodeKind.TABLE_CELL,
-                NodeKind.TABLE_CELL,
             ],
         ):
             self.assertEqual(c.kind, kind)
+        tree = self.parse(
+            "test",
+            """{|
+||bar
+| |baz
+| zap
+|}""",
+        )
+        row = tree.children[0].children[0]
+        self.assertEqual(len(row.children), 3)
 
     def test_table_bang1(self):
         # Testing that the single exclamation mark in the middle of a table


### PR DESCRIPTION
On Wiktionary, `||` at the line beginning inside a table is expanded to a single `<td>` HTML element. Previous code produces an extra empty table cell node and makes it more difficult for extractor code to decide whether to discard the cell.

`test_table_hdr4` was added in commit 1f48e90 for en edition page "山 歩き" and the extracted forms list is the same after this change.