### PR TITLE
Type hint `core.node_to_text`

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -1942,7 +1942,7 @@ class Wtp:
         template_fn=None,
         post_template_fn=None,
         node_handler_fn=None,
-    ):
+    ) -> str:
         """Converts the given parse tree node to plain text."""
         return to_text(
             self,


### PR DESCRIPTION
Should hold true since that function is only a wrapper call to `to_text` which returns a `str`.