### PR TITLE
Create utility functions to check for lists and list items

### DIFF
--- a/src/wikitextprocessor/parser.py
+++ b/src/wikitextprocessor/parser.py
@@ -2494,3 +2494,19 @@ def print_tree(
     else:
         print("\n".join(parts))
         return None
+
+
+def is_list(node: WikiNode) -> bool:
+    return (
+        isinstance(node, WikiNode)
+        and node.kind == NodeKind.LIST
+        or (isinstance(node, HTMLNode) and node.tag in ("ul", "ol"))
+    )
+
+
+def is_list_item(node: WikiNode) -> bool:
+    return (
+        isinstance(node, WikiNode)
+        and node.kind == NodeKind.LIST_ITEM
+        or (isinstance(node, HTMLNode) and node.tag == "li")
+    )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -11,6 +11,8 @@ from wikitextprocessor.parser import (
     NodeKind,
     TemplateNode,
     WikiNode,
+    is_list,
+    is_list_item,
     print_tree,
 )
 
@@ -3259,6 +3261,76 @@ text</ref>
                 ["Armenian Phrases | learn101.org"],
             ],
         )
+
+    def test_is_list_fn(self):
+        self.ctx.start_page("test")
+        root = self.ctx.parse(
+            """* test
+** test2
+"""
+        )
+        self.assertFalse(is_list(root))
+        main_list = root.children[0]
+        self.assertTrue(is_list(main_list))
+        item1 = main_list.children[0]
+        test_text = item1.children[0]
+        test2_list = item1.children[1]
+        self.assertFalse(is_list(item1))
+        self.assertFalse(is_list(test_text))
+        self.assertTrue(is_list(test2_list))
+
+    def test_is_list_fn_2(self):
+        self.ctx.start_page("test")
+        root = self.ctx.parse(
+            """<ul><li>test<ul><li>test2</li></ul></ul>
+"""
+        )
+        self.assertFalse(is_list(root))
+        main_list = root.children[0]
+        self.assertTrue(is_list(main_list))
+        item1 = main_list.children[0]
+        test_text = item1.children[0]
+        test2_list = item1.children[1]
+        self.assertFalse(is_list(item1))
+        self.assertFalse(is_list(test_text))
+        self.assertTrue(is_list(test2_list))
+
+    def test_is_list_item_fn(self):
+        self.ctx.start_page("test")
+        root = self.ctx.parse(
+            """* test
+** test2
+"""
+        )
+        self.assertFalse(is_list_item(root))
+        main_list = root.children[0]
+        self.assertFalse(is_list_item(main_list))
+        item1 = main_list.children[0]
+        test_text = item1.children[0]
+        test2_list = item1.children[1]
+        self.assertTrue(is_list_item(item1))
+        self.assertFalse(is_list_item(test_text))
+        self.assertFalse(is_list_item(test2_list))
+        item2 = test2_list.children[0]
+        self.assertTrue(is_list_item(item2))
+
+    def test_is_list_item_fn_2(self):
+        self.ctx.start_page("test")
+        root = self.ctx.parse(
+            """<ul><li>test<ul><li>test2</li></ul></ul>
+"""
+        )
+        self.assertFalse(is_list_item(root))
+        main_list = root.children[0]
+        self.assertFalse(is_list_item(main_list))
+        item1 = main_list.children[0]
+        test_text = item1.children[0]
+        test2_list = item1.children[1]
+        self.assertTrue(is_list_item(item1))
+        self.assertFalse(is_list_item(test_text))
+        self.assertFalse(is_list_item(test2_list))
+        item2 = test2_list.children[0]
+        self.assertTrue(is_list_item(item2))
 
 
 # XXX implement <nowiki/> marking for links, templates


### PR DESCRIPTION
This was becoming common enough in the code that I felt that it makes sense to have these.

You could try to make some kind of subclass multiple- inheritance thing with something like "ListNode" and "ListItemNode"... But that feels that it would be messy. Do you have a HTMLListNode class?? That's just the same thing all over again. Adding this functionality into WikiNode doesn't feel exactly correct either, although we could create a function that returns something more general than the contents of the `kind` field, like, "WikiNode.functionality" -> returning an enum or literal that tells you that it's a list or a list item...