### PR TITLE
Retry after wikidata query failure

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -25,6 +25,8 @@ from typing import (
     Union,
 )
 
+from requests import Session
+
 from .common import (
     MAGIC_FIRST,
     MAGIC_LBRACKET_CHAR,
@@ -279,6 +281,7 @@ class Wtp:
         "parser_function_aliases",
         "notes",  # NOTE error messages
         "wiki_notices",  # WIKI error messages
+        "wikidata_session",
     )
 
     def __init__(
@@ -351,6 +354,7 @@ class Wtp:
         self.parser_function_aliases = parser_function_aliases
         if not quiet:
             logger.setLevel(logging.DEBUG)
+        self.wikidata_session: Session | None = None
 
     def create_db(self) -> None:
         from .wikidata import init_wikidata_cache
@@ -404,6 +408,8 @@ class Wtp:
             for path in self.db_path.parent.glob(self.db_path.name + "*"):
                 # also remove SQLite -wal and -shm file
                 path.unlink(True)
+        if self.wikidata_session is not None:
+            self.wikidata_session.close()
 
     def has_analyzed_templates(self) -> bool:
         for (result,) in self.db_conn.execute(

--- a/src/wikitextprocessor/interwiki.py
+++ b/src/wikitextprocessor/interwiki.py
@@ -7,6 +7,8 @@ if TYPE_CHECKING:
 def get_interwiki_data(wtp: "Wtp") -> list[dict[str, Union[str, bool]]]:
     import requests
 
+    from .wikidata import get_user_agent
+
     r = requests.get(
         f"https://{wtp.lang_code}.{wtp.project}.org/w/api.php",
         params={  # type: ignore
@@ -16,7 +18,7 @@ def get_interwiki_data(wtp: "Wtp") -> list[dict[str, Union[str, bool]]]:
             "format": "json",
             "formatversion": 2,
         },
-        headers={"user-agent": "wikitextprocessor"},
+        headers={"user-agent": get_user_agent()},
     )
     if r.ok:
         results = r.json()

--- a/tests/test_lua.py
+++ b/tests/test_lua.py
@@ -421,7 +421,7 @@ return export""",
         )
 
     @patch(
-        "requests.get",
+        "requests.Session.get",
         return_value=MockRequests(True, {"entities": {"Q42": {"id": "Q42"}}}),
     )
     def test_wikidata_get_entity(self, mock_request):
@@ -443,7 +443,7 @@ return export""",
         mock_request.assert_called_once()
 
     @patch(
-        "requests.get",
+        "requests.Session.get",
         return_value=MockRequests(
             True,
             {
@@ -540,7 +540,7 @@ return export""",
         self.assertEqual(self.wtp.expand("{{#invoke:test|test}}"), "value")
 
     @patch(
-        "requests.get",
+        "requests.Session.get",
         return_value=MockRequests(
             True,
             {


### PR DESCRIPTION
There are some wikidata query failed error in the log that has never happened before, apply the following changes and hope this could reduce errors

- update user agent
- use session
- enable backoff
- fallback to English if an item doesn't have edition's language data