### PR TITLE
Fix `index out of range` exception in en page "aderedor"

### DIFF
--- a/src/wikitextprocessor/parser.py
+++ b/src/wikitextprocessor/parser.py
@@ -868,11 +868,13 @@ def close_begline_lists(ctx: "Wtp") -> None:
     """Closes currently open list if at the beginning of a line."""
     if not (ctx.beginning_of_line and ctx.begline_enabled):
         return
-    # only check if the last direct parent node is HTML
+    # don't close list if inside <ref> and no list inside <ref>
     # if list doesn't close properly, update this code
-    node = ctx.parser_stack[-1]
-    if isinstance(node, HTMLNode) and node.tag in ctx.paired_html_tags:
-        return
+    for node in ctx.parser_stack[::-1]:
+        if isinstance(node, WikiNode) and node.kind == NodeKind.LIST:
+            break
+        elif isinstance(node, HTMLNode) and node.tag == "ref":
+            return
     while _parser_have(ctx, NodeKind.LIST):
         _parser_pop(ctx, True)
 
@@ -2123,7 +2125,7 @@ token_list: list[str] = [
     r"\|\+",
     r"\|-",
     r"!!",
-    r"\s*https?://[a-zA-Z0-9.]+(/[^][{}<>|\s]*)?",
+    r"\s*https?://[\w.-]+(/[^][{}<>|\s]*)?",
     r"^[ \t]*!",
     r"\|\|",
     r"\|",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3351,6 +3351,23 @@ text</ref>
         item2 = test2_list.children[0]
         self.assertTrue(is_list_item(item2))
 
+    def test_newline_in_ref(self):
+        self.ctx.start_page("aderedor")
+        root = self.ctx.parse(
+            """* {{alt|roa-ole|deredor}}<ref> Diccionario del Español Medieval,
+http://purl.uni-rostock.de/demel/d00649426</ref>"""
+        )
+        list_item = root.children[0].children[0]
+        self.assertEqual(len(list_item.children), 3)
+        ref_node = list_item.children[2]
+        self.assertIsInstance(ref_node, HTMLNode)
+        self.assertEqual(ref_node.tag, "ref")
+        url_node = ref_node.children[1]
+        self.assertEqual(url_node.kind, NodeKind.URL)
+        self.assertEqual(
+            url_node.largs, [["http://purl.uni-rostock.de/demel/d00649426"]]
+        )
+
 
 # XXX implement <nowiki/> marking for links, templates
 #  - https://en.wikipedia.org/wiki/Help:Wikitext#Nowiki


### PR DESCRIPTION
only check direct HTML parent node is not enough