### PR TITLE
Add option to not print output

### DIFF
--- a/src/wikitextprocessor/core.py
+++ b/src/wikitextprocessor/core.py
@@ -283,6 +283,7 @@ class Wtp:
         "wiki_notices",  # WIKI error messages
         "wikidata_session",
         "linktrailing_re",
+        "quiet_output", # Prevent errors printed to stdout
     )
 
     def __init__(
@@ -294,6 +295,7 @@ class Wtp:
         extension_tags: Optional[dict[str, HTMLTagData]] = None,
         parser_function_aliases: dict[str, str] = {},
         quiet: bool = False,
+        quiet_output: bool = False,
     ):
         if isinstance(db_path, str):
             self.db_path: Optional[Path] = Path(db_path)
@@ -355,6 +357,7 @@ class Wtp:
         self.parser_function_aliases = parser_function_aliases
         if not quiet:
             logger.setLevel(logging.DEBUG)
+        self.quiet_output = quiet_output
         self.wikidata_session: Session | None = None
         # Default regex pattern, will sometimes cause trouble.
         # Linktrailing is when you have [[a li]]nk that consumes the
@@ -494,6 +497,8 @@ class Wtp:
             }
 
     def _fmt_errmsg(self, kind: str, msg: str, trace: Optional[str]) -> None:
+        if self.quiet_output:
+            return
         assert isinstance(kind, str)
         assert isinstance(msg, str)
         assert isinstance(trace, (str, type(None)))


### PR DESCRIPTION
Add 'quiet_output' to Wtp to not print errors to stdout via _fmt_errmsg()

When parsing a dump the output from errors (`Wtp.error()` and the likes) can be quite overwhelming, and not needed when all the errors are accessible via `Wtp.to_return()` in a parsable data structure. This new option to `Wtp` helps keep the output quiet when it is not needed.
I considered using the `quiet` parameter, but its current use is to quiet the logging. Better not mix things up I suppose.

Usage:
```
wtp = Wtp(quiet_output=True)
```
(Defaults to False, current behavior)


NB: the error messages sent to stdout cause a problem with unittest for `wiktextractor` where the parser is run in threads, in which case the stdout of the threads can't be captured by unittest. This PR is an attempt to mitigate that problem without drastic changes to the current behavior of the code.